### PR TITLE
Bump pipeline-dashboard version from 0.0.7 to 0.0.8

### DIFF
--- a/cicd/lib/pipeline-dashboard.ts
+++ b/cicd/lib/pipeline-dashboard.ts
@@ -8,7 +8,7 @@ export default class PipelineDashboard extends cdk.Construct {
       location: {
         applicationId:
           'arn:aws:serverlessrepo:us-east-1:923120264911:applications/pipeline-dashboard',
-        semanticVersion: '0.0.7'
+        semanticVersion: '0.0.8'
       },
       parameters: {
         PipelinePattern: '*'


### PR DESCRIPTION
The `Deploy the CI/CD Pipeline` step of the quick start was failing with the following error

`
The following resource(s) failed to create: [PipelineDashboardEventHandler, PipelineDashboardGenerator].`

To resolve the issue I had to bump the pipeline-dashboard version to 0.0.8 which is the latest version in the SAR -> https://serverlessrepo.aws.amazon.com/applications/arn:aws:serverlessrepo:us-east-1:923120264911:applications~pipeline-dashboard
