### PR TITLE
Updated Github access token instructions

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -39,7 +39,7 @@ Set up CodeBuild GitHub access. There are a couple of ways to do this. The most 
 aws codebuild import-source-credentials --generate-cli-skeleton > /tmp/skeleton.json
 ```
 
-2. Create a GitHub personal access token. Go to GitHub -> Settings -> Developer Settings -> Personal access tokens -> Select 'repo'.
+2. Create a GitHub personal access token. Go to GitHub -> Settings -> Developer Settings -> Personal access tokens -> Generate new token -> Select 'repo'.
 3. Paste the token into `token` in `/tmp/skeleton.json`
 4. Change `serverType` to `GITHUB`
 5. Change `authType` to `PERSONAL_ACCESS_TOKEN`


### PR DESCRIPTION
Added an additional step (select "Generate new token") in section 3.2 to keep instructions up to date with Github's user interface.

"repo" can only selected when the user clicks "generate new token".

Before clicking the button:
![image](https://user-images.githubusercontent.com/23701145/124499827-9778e100-ddb6-11eb-8c14-8c139e0ddf26.png)

After clicking the button:
![image](https://user-images.githubusercontent.com/23701145/124499949-c727e900-ddb6-11eb-8df3-49e754d8e905.png)
