### PR TITLE
build(sls): v3 upgrade prep for new lambda hashing algorithm

### DIFF
--- a/api-service/serverless.yml
+++ b/api-service/serverless.yml
@@ -7,6 +7,7 @@ provider:
   runtime: nodejs12.x
   stage: ${opt:stage, 'local'}
   region: ${opt:region}
+  lambdaHashingVersion: 20201221
 
 custom:
   app: ${file(../app.yml)}

--- a/build-scripts/deploy-module.sh
+++ b/build-scripts/deploy-module.sh
@@ -9,4 +9,5 @@ if [ "${MODULE_NAME}" == "certs" ]; then
   TARGET_REGION="us-east-1"
 fi
 
-../node_modules/serverless/bin/serverless.js deploy --stage ${SLIC_STAGE} --region ${TARGET_REGION} --force
+../node_modules/serverless/bin/serverless.js deploy --stage ${SLIC_STAGE} --region ${TARGET_REGION} --force --enforce-hash-update --verbose
+../node_modules/serverless/bin/serverless.js deploy --stage ${SLIC_STAGE} --region ${TARGET_REGION} --force --verbose

--- a/checklist-service/serverless.yml
+++ b/checklist-service/serverless.yml
@@ -34,6 +34,7 @@ provider:
   logs:
     restApi: true
   logRetentionInDays: 7
+  lambdaHashingVersion: 20201221
 
 custom:
   app: ${file(../app.yml)}

--- a/email-service/serverless.yml
+++ b/email-service/serverless.yml
@@ -22,6 +22,7 @@ provider:
     SLIC_STAGE: ${self:provider.stage}
     SES_REGION: ${self:provider.sesRegion}
   logRetentionInDays: 7
+  lambdaHashingVersion: 20201221
 
 custom:
   app: ${file(../app.yml)}

--- a/sharing-service/serverless.yml
+++ b/sharing-service/serverless.yml
@@ -28,6 +28,7 @@ provider:
     SLIC_STAGE: ${self:provider.stage}
     EMAIL_QUEUE_NAME: ${self:custom.emailQueueName}
   logRetentionInDays: 7
+  lambdaHashingVersion: 20201221
 
 custom:
   app: ${file(../app.yml)}

--- a/user-service/serverless.yml
+++ b/user-service/serverless.yml
@@ -23,6 +23,7 @@ provider:
   logs:
     restApi: true
   logRetentionInDays: 7
+  lambdaHashingVersion: 20201221
 
 custom:
   app: ${file(../app.yml)}

--- a/welcome-service/serverless.yml
+++ b/welcome-service/serverless.yml
@@ -19,6 +19,7 @@ provider:
   environment:
     SLIC_STAGE: ${self:provider.stage}
   logRetentionInDays: 7
+  lambdaHashingVersion: 20201221
 
 custom:
   app: ${file(../app.yml)}


### PR DESCRIPTION
* The Lambda version hashing algorithm has now changed in serverless framework version 3. 
* The changes in this PR are to assist upgrading in to the new algorithm whilst on version 2, before upgrading to version 3 in a follow up PR (https://github.com/fourTheorem/slic-starter/pull/194) as recommended on the serverless framework upgrade docs - https://www.serverless.com/framework/docs/guides/upgrading-v3#lambda-hashing-algorithm
* Once merged, the deployment will handle the upgrade with a follow up deployment to ensure all Lambda descriptions are restored

Note: excludes stacks where no Lambdas are defined (frontend, certs, api)