### PR TITLE
ci(cicd): fix skip mutation condition for self synth job

### DIFF
--- a/cicd/stacks/pipeline-stack.ts
+++ b/cicd/stacks/pipeline-stack.ts
@@ -75,7 +75,7 @@ export class PipelineStack extends Stack {
 
     const deployAccount = this.node.tryGetContext('deploy-account') || this.account
     const deployRegion = this.node.tryGetContext('deploy-region') || this.region
-    const skipSelfMutation = Boolean(this.node.tryGetContext('skip-self-mutation') || 'false')
+    const skipSelfMutation = Boolean(this.node.tryGetContext('skip-self-mutation') || false)
 
     const cdkContextArgs = [
       `--context stages=${stages.join(',')}`,


### PR DESCRIPTION
* This PR fixes the condition to check whether the `CdkSynth` should be skipped or not based on the config argument being passed in or not
* This fixes the CodePipeline job on prod deploys to ensure that the CodeBuild and CodePipeline resources are also being updated 