### PR TITLE
chore: update script failure options and remove `CROSS_ACCOUNT_ID` env var

### DIFF
--- a/build-scripts/assume-cross-account-role.env
+++ b/build-scripts/assume-cross-account-role.env
@@ -4,7 +4,7 @@ if [[ "${ROLE_ARN}" == "" ]]; then
 fi
 
 SESSION_NAME=${SLIC_STAGE}SLICDeploy
-echo Assuming role ${ROLE_ARN} in account ${CROSS_ACCOUNT_ID} with session name ${SESSION_NAME}
+echo Assuming role ${ROLE_ARN} with session name ${SESSION_NAME}
 
 IMPERSONATION=$(aws sts assume-role --role-arn "${ROLE_ARN}" --role-session-name ${SESSION_NAME} --output text | tail -1)
 export AWS_ACCESS_KEY_ID=$(echo $IMPERSONATION | awk '{print $2}')

--- a/build-scripts/audit-module.sh
+++ b/build-scripts/audit-module.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -Eeuox pipefail
+set -Eeuxo pipefail
 AUDIT_ARGS="--audit-level=high"
 
 npm install -g npm@latest

--- a/build-scripts/build-module.sh
+++ b/build-scripts/build-module.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
-
-set -Eeuox pipefail
+set -Eeuxo pipefail
 
 source build-scripts/assume-cross-account-role.env
 
-# This script assumes that `npm ci` or `npm install` has already been run in the root and the module
+# This script assumes that `npm ci` or `npm install` has already been run in the root of the project.
 # Some modules may require a module-specific build
 cd packages/"${MODULE_NAME}"
 if [ -e ./scripts/build.sh ]; then
+
   bash ./scripts/build.sh
 fi

--- a/build-scripts/deploy-module.sh
+++ b/build-scripts/deploy-module.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -Eeuox pipefail
+set -Eeuxo pipefail
 
 source build-scripts/assume-cross-account-role.env
 cd packages/"${MODULE_NAME}"

--- a/build-scripts/orchestrator-stage-deploy.sh
+++ b/build-scripts/orchestrator-stage-deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -Eeuox pipefail
+set -Eeuxo pipefail
 
 echo PIPELINE STATE:
 cat pipeline-state.env

--- a/build-scripts/package-module.sh
+++ b/build-scripts/package-module.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -Eeuox pipefail
+set -Eeuxo pipefail
 
 source build-scripts/assume-cross-account-role.env
 cd packages/"${MODULE_NAME}"

--- a/build-scripts/source-kickoff.sh
+++ b/build-scripts/source-kickoff.sh
@@ -8,7 +8,7 @@ LOCAL_DEPLOYMENT_STATE=/tmp/deployment-state.env
 
 aws s3 cp s3://${DEPLOYMENT_STATE_BUCKET}/${DEPLOYMENT_STATE_KEY} ${LOCAL_DEPLOYMENT_STATE}
 
-set -Eeuox pipefail
+set -Eeuxo pipefail
 
 REPO_URL=$1
 TARGET_VERSION=$2

--- a/build-scripts/update-deployment-state.sh
+++ b/build-scripts/update-deployment-state.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -Eeuox pipefail
+set -Eeuxo pipefail
 
 source pipeline-state.env
 

--- a/packages/cicd/stacks/pipeline-stack.ts
+++ b/packages/cicd/stacks/pipeline-stack.ts
@@ -276,10 +276,6 @@ export class PipelineStack extends Stack {
             type: codeBuild.BuildEnvironmentVariableType.PLAINTEXT,
             value: stage
           },
-          CROSS_ACCOUNT_ID: {
-            type: codeBuild.BuildEnvironmentVariableType.PLAINTEXT,
-            value: targetAccounts[stage]
-          },
           MAILOSAUR_API_KEY: {
             type: codeBuild.BuildEnvironmentVariableType.PARAMETER_STORE,
             value: ssmParams.Test.MAILOSAUR_API_KEY

--- a/packages/e2e-tests/codebuild-run-tests.sh
+++ b/packages/e2e-tests/codebuild-run-tests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -Eeuox pipefail
+set -Eeuxo pipefail
 
 source ../../build-scripts/assume-cross-account-role.env
 npm run headless

--- a/packages/frontend/scripts/build.sh
+++ b/packages/frontend/scripts/build.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -Eeuox pipefail
+set -Eeuxo pipefail
 
 echo frontend build.sh
 npm run build

--- a/packages/frontend/scripts/deploy.sh
+++ b/packages/frontend/scripts/deploy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -Eeuox pipefail
+set -Eeuxo pipefail
 
 if [[ -z "${STAGE}" ]]; then
   echo STAGE must be set

--- a/packages/integration-tests/codebuild-run-tests.sh
+++ b/packages/integration-tests/codebuild-run-tests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -Eeuox pipefail
+set -Eeuxo pipefail
 
 source ../../build-scripts/assume-cross-account-role.env
 npm test

--- a/packages/integration-tests/run_seq.sh
+++ b/packages/integration-tests/run_seq.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -Eeuox pipefail
+set -Eeuxo pipefail
 
 num=$1
 


### PR DESCRIPTION
* Reorder script options to be more readable when setting options
* Remove an unused env var `CROSS_ACCOUNT_ID` since we define the full role arn for the roles to be assumed for cross-account access