### PR TITLE
ci(gha): disable husky commit hooks when running semantic-release

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -21,6 +21,7 @@ jobs:
       - run: npm ci --dev --workspaces false --fund false
       - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HUSKY: 0
         run: npm run release
   lint-commits:
     runs-on: ubuntu-latest


### PR DESCRIPTION
* Ignore running husky hooks as they require full set of dependencies to be installed for running unit tests
* Since running semantic-release implicitly implies that all previous jobs have succeeded, running husky hooks is redundant and should be skipped