### PR TITLE
feat(email-service): use aws-sdk v3

### DIFF
--- a/packages/email-service/package.json
+++ b/packages/email-service/package.json
@@ -17,7 +17,8 @@
     "url": "https://github.com/fourTheorem/slic-starter"
   },
   "devDependencies": {
-    "aws-sdk-mock": "^5.7.0",
+    "@aws-sdk/client-sesv2": "^3.118.0",
+    "aws-sdk-client-mock": "^1.0.0",
     "awscred": "^1.5.0",
     "serverless-bundle": "^5.3.0",
     "serverless-iam-roles-per-function": "^3.2.0",


### PR DESCRIPTION
* Migrate to v3 of the aws-sdk as its stable and is now recommended for general use
* Rework tests to remove usage of redunant mocks and move away from `aws-sdk-mock`
* Full benefits listed here: https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/index.html