### PR TITLE
Replace proxyquire with t.mock for tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,6 @@
         "eslint-plugin-testcafe": "^0.2.1",
         "husky": "^8.0.1",
         "lint-staged": "^13.0.1",
-        "proxyquire": "^2.1.3",
         "semantic-release": "^19.0.3",
         "serverless": "^3.19.0",
         "tap": "^16.2.0"
@@ -6432,8 +6431,9 @@
     },
     "node_modules/@aws-sdk/middleware-retry/node_modules/@jest/types": {
       "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+      "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -6447,42 +6447,32 @@
       }
     },
     "node_modules/@aws-sdk/middleware-retry/node_modules/@react-native-community/cli": {
-      "version": "7.0.3",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-8.0.2.tgz",
+      "integrity": "sha512-IwG3f6gKPlJucFH1Ex0SMD1P1rtOpdR9lloWoBZh3y0dbUbsNtiZZz0zJjZFm/2mtrIihplL7Yz3LmQBNm7xBQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@react-native-community/cli-debugger-ui": "^7.0.3",
-        "@react-native-community/cli-hermes": "^6.3.0",
-        "@react-native-community/cli-plugin-metro": "^7.0.3",
-        "@react-native-community/cli-server-api": "^7.0.3",
-        "@react-native-community/cli-tools": "^6.2.0",
-        "@react-native-community/cli-types": "^6.0.0",
-        "appdirsjs": "^1.2.4",
+        "@react-native-community/cli-clean": "^8.0.0",
+        "@react-native-community/cli-config": "^8.0.2",
+        "@react-native-community/cli-debugger-ui": "^8.0.0",
+        "@react-native-community/cli-doctor": "^8.0.2",
+        "@react-native-community/cli-hermes": "^8.0.2",
+        "@react-native-community/cli-plugin-metro": "^8.0.0",
+        "@react-native-community/cli-server-api": "^8.0.0",
+        "@react-native-community/cli-tools": "^8.0.0",
+        "@react-native-community/cli-types": "^8.0.0",
         "chalk": "^4.1.2",
-        "command-exists": "^1.2.8",
         "commander": "^2.19.0",
-        "cosmiconfig": "^5.1.0",
-        "deepmerge": "^3.2.0",
-        "envinfo": "^7.7.2",
         "execa": "^1.0.0",
         "find-up": "^4.1.0",
         "fs-extra": "^8.1.0",
-        "glob": "^7.1.3",
         "graceful-fs": "^4.1.3",
-        "joi": "^17.2.1",
         "leven": "^3.1.0",
         "lodash": "^4.17.15",
         "minimist": "^1.2.0",
-        "node-stream-zip": "^1.9.1",
-        "ora": "^3.4.0",
-        "pretty-format": "^26.6.2",
         "prompts": "^2.4.0",
-        "semver": "^6.3.0",
-        "serve-static": "^1.13.1",
-        "strip-ansi": "^5.2.0",
-        "sudo-prompt": "^9.0.0",
-        "wcwidth": "^1.0.1"
+        "semver": "^6.3.0"
       },
       "bin": {
         "react-native": "build/bin.js"
@@ -6494,26 +6484,11 @@
         "react-native": "*"
       }
     },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/@react-native-community/cli-tools": {
-      "version": "6.2.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "appdirsjs": "^1.2.4",
-        "chalk": "^4.1.2",
-        "lodash": "^4.17.15",
-        "mime": "^2.4.1",
-        "node-fetch": "^2.6.0",
-        "open": "^6.2.0",
-        "semver": "^6.3.0",
-        "shell-quote": "1.6.1"
-      }
-    },
     "node_modules/@aws-sdk/middleware-retry/node_modules/@types/yargs": {
       "version": "15.0.14",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
+      "integrity": "sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -6521,8 +6496,9 @@
     },
     "node_modules/@aws-sdk/middleware-retry/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -6534,19 +6510,11 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/argparse": {
-      "version": "1.0.10",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
     "node_modules/@aws-sdk/middleware-retry/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -6559,22 +6527,11 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/cli-cursor": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "restore-cursor": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@aws-sdk/middleware-retry/node_modules/color-convert": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
@@ -6585,35 +6542,23 @@
     },
     "node_modules/@aws-sdk/middleware-retry/node_modules/color-name": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/@aws-sdk/middleware-retry/node_modules/commander": {
       "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true
-    },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/cosmiconfig": {
-      "version": "5.2.1",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "import-fresh": "^2.0.0",
-        "is-directory": "^0.3.1",
-        "js-yaml": "^3.13.1",
-        "parse-json": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/@aws-sdk/middleware-retry/node_modules/cross-spawn": {
       "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "nice-try": "^1.0.4",
@@ -6628,26 +6573,19 @@
     },
     "node_modules/@aws-sdk/middleware-retry/node_modules/cross-spawn/node_modules/semver": {
       "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true,
-      "license": "ISC",
       "peer": true,
       "bin": {
         "semver": "bin/semver"
       }
     },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/deepmerge": {
-      "version": "3.3.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-retry/node_modules/execa": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "cross-spawn": "^6.0.0",
@@ -6664,8 +6602,9 @@
     },
     "node_modules/@aws-sdk/middleware-retry/node_modules/find-up": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "locate-path": "^5.0.0",
@@ -6677,8 +6616,9 @@
     },
     "node_modules/@aws-sdk/middleware-retry/node_modules/fs-extra": {
       "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -6691,8 +6631,9 @@
     },
     "node_modules/@aws-sdk/middleware-retry/node_modules/get-stream": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "pump": "^3.0.0"
@@ -6703,61 +6644,29 @@
     },
     "node_modules/@aws-sdk/middleware-retry/node_modules/has-flag": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=8"
       }
     },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/import-fresh": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "caller-path": "^2.0.0",
-        "resolve-from": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@aws-sdk/middleware-retry/node_modules/is-stream": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/is-wsl": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/@aws-sdk/middleware-retry/node_modules/jsonfile": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
@@ -6765,8 +6674,9 @@
     },
     "node_modules/@aws-sdk/middleware-retry/node_modules/locate-path": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "p-locate": "^4.1.0"
@@ -6775,93 +6685,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/log-symbols": {
-      "version": "2.2.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "chalk": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/log-symbols/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/log-symbols/node_modules/chalk": {
-      "version": "2.4.2",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/log-symbols/node_modules/color-convert": {
-      "version": "1.9.3",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/log-symbols/node_modules/color-name": {
-      "version": "1.1.3",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/log-symbols/node_modules/has-flag": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/log-symbols/node_modules/supports-color": {
-      "version": "5.5.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/mimic-fn": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@aws-sdk/middleware-retry/node_modules/npm-run-path": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "path-key": "^2.0.0"
@@ -6870,113 +6698,11 @@
         "node": ">=4"
       }
     },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/onetime": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "mimic-fn": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/open": {
-      "version": "6.4.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "is-wsl": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/ora": {
-      "version": "3.4.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "chalk": "^2.4.2",
-        "cli-cursor": "^2.1.0",
-        "cli-spinners": "^2.0.0",
-        "log-symbols": "^2.2.0",
-        "strip-ansi": "^5.2.0",
-        "wcwidth": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/ora/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/ora/node_modules/chalk": {
-      "version": "2.4.2",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/ora/node_modules/color-convert": {
-      "version": "1.9.3",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/ora/node_modules/color-name": {
-      "version": "1.1.3",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/ora/node_modules/has-flag": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/ora/node_modules/supports-color": {
-      "version": "5.5.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@aws-sdk/middleware-retry/node_modules/p-limit": {
       "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "p-try": "^2.0.0"
@@ -6990,8 +6716,9 @@
     },
     "node_modules/@aws-sdk/middleware-retry/node_modules/p-locate": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "p-limit": "^2.2.0"
@@ -7002,30 +6729,19 @@
     },
     "node_modules/@aws-sdk/middleware-retry/node_modules/p-try": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=6"
       }
     },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/parse-json": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@aws-sdk/middleware-retry/node_modules/path-exists": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=8"
@@ -7033,8 +6749,9 @@
     },
     "node_modules/@aws-sdk/middleware-retry/node_modules/path-key": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=4"
@@ -7042,8 +6759,9 @@
     },
     "node_modules/@aws-sdk/middleware-retry/node_modules/pretty-format": {
       "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+      "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@jest/types": "^26.6.2",
@@ -7065,54 +6783,56 @@
       }
     },
     "node_modules/@aws-sdk/middleware-retry/node_modules/react": {
-      "version": "17.0.2",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.0.0.tgz",
+      "integrity": "sha512-x+VL6wbT4JRVPm7EGxXhZ8w8LTROaxPXOqhlGyVSrv0sB1jkyFGgXxJ8LVoPRLvPR6/CIZGFmfzqUa2NYeMr2A==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/@aws-sdk/middleware-retry/node_modules/react-native": {
-      "version": "0.68.2",
+      "version": "0.69.1",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.69.1.tgz",
+      "integrity": "sha512-585NmzSuYUfday8YsfqgreFAZbXRI/kxKsiuaShwGHgkwdtmE5qA7WfGItgxZBOZD6g/Hm1YBUqSwIm07tPa6A==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^27.0.1",
-        "@react-native-community/cli": "^7.0.3",
-        "@react-native-community/cli-platform-android": "^7.0.1",
-        "@react-native-community/cli-platform-ios": "^7.0.1",
+        "@react-native-community/cli": "^8.0.0",
+        "@react-native-community/cli-platform-android": "^8.0.0",
+        "@react-native-community/cli-platform-ios": "^8.0.0",
         "@react-native/assets": "1.0.0",
         "@react-native/normalize-color": "2.0.0",
         "@react-native/polyfills": "2.0.0",
         "abort-controller": "^3.0.0",
         "anser": "^1.4.9",
         "base64-js": "^1.1.2",
-        "deprecated-react-native-prop-types": "^2.3.0",
         "event-target-shim": "^5.0.1",
         "hermes-engine": "~0.11.0",
         "invariant": "^2.2.4",
         "jsc-android": "^250230.2.1",
-        "metro-react-native-babel-transformer": "0.67.0",
-        "metro-runtime": "0.67.0",
-        "metro-source-map": "0.67.0",
+        "memoize-one": "^5.0.0",
+        "metro-react-native-babel-transformer": "0.70.3",
+        "metro-runtime": "0.70.3",
+        "metro-source-map": "0.70.3",
+        "mkdirp": "^0.5.1",
         "nullthrows": "^1.1.1",
         "pretty-format": "^26.5.2",
         "promise": "^8.0.3",
-        "react-devtools-core": "^4.23.0",
-        "react-native-codegen": "^0.0.17",
-        "react-native-gradle-plugin": "^0.0.6",
+        "react-devtools-core": "4.24.0",
+        "react-native-codegen": "^0.69.1",
+        "react-native-gradle-plugin": "^0.0.7",
         "react-refresh": "^0.4.0",
         "react-shallow-renderer": "16.14.1",
         "regenerator-runtime": "^0.13.2",
-        "scheduler": "^0.20.2",
+        "scheduler": "^0.21.0",
         "stacktrace-parser": "^0.1.3",
-        "use-subscription": ">=1.0.0 <1.6.0",
+        "use-sync-external-store": "^1.0.0",
         "whatwg-fetch": "^3.0.0",
         "ws": "^6.1.4"
       },
@@ -7123,7 +6843,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "react": "17.0.2"
+        "react": "18.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-retry/node_modules/react-native-get-random-values": {
@@ -7146,42 +6866,21 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/resolve-from": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/restore-cursor": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "onetime": "^2.0.0",
-        "signal-exit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@aws-sdk/middleware-retry/node_modules/scheduler": {
-      "version": "0.20.2",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.21.0.tgz",
+      "integrity": "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/@aws-sdk/middleware-retry/node_modules/shebang-command": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "shebang-regex": "^1.0.0"
@@ -7192,50 +6891,19 @@
     },
     "node_modules/@aws-sdk/middleware-retry/node_modules/shebang-regex": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/shell-quote": {
-      "version": "1.6.1",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "array-filter": "~0.0.0",
-        "array-map": "~0.0.0",
-        "array-reduce": "~0.0.0",
-        "jsonify": "~0.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/strip-ansi/node_modules/ansi-regex": {
-      "version": "4.1.1",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/@aws-sdk/middleware-retry/node_modules/supports-color": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -7246,8 +6914,9 @@
     },
     "node_modules/@aws-sdk/middleware-retry/node_modules/universalify": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">= 4.0.0"
@@ -7263,8 +6932,9 @@
     },
     "node_modules/@aws-sdk/middleware-retry/node_modules/which": {
       "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
-      "license": "ISC",
       "peer": true,
       "dependencies": {
         "isexe": "^2.0.0"
@@ -8370,8 +8040,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.17.12",
-      "license": "MIT",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.18.6.tgz",
+      "integrity": "sha512-gvZnm1YAAxh13eJdkb9EWHBnF3eAub3XTLCZEehHT2kWxiKVRL64+ae5Y6Ivne0mVHmMYKT+xWgZO+gQhuLUBg==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -8599,13 +8270,14 @@
       }
     },
     "node_modules/@babel/plugin-proposal-export-default-from": {
-      "version": "7.17.12",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-default-from/-/plugin-proposal-export-default-from-7.18.6.tgz",
+      "integrity": "sha512-oTvzWB16T9cB4j5kX8c8DuUHo/4QtR2P9vnUNKed9xqFP8Jos/IRniz1FiIryn6luDYoltDJSYF7RCpbm2doMg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.17.12",
-        "@babel/plugin-syntax-export-default-from": "^7.16.7"
+        "@babel/helper-plugin-utils": "^7.18.6",
+        "@babel/plugin-syntax-export-default-from": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -8843,12 +8515,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-export-default-from": {
-      "version": "7.16.7",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-default-from/-/plugin-syntax-export-default-from-7.18.6.tgz",
+      "integrity": "sha512-Kr//z3ujSVNx6E9z9ih5xXXMqK07VVTuqPmqGe6Mss/zW5XPeLZeSDZoP9ab/hT4wPKqAgjl2PnhPrcpk8Seew==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.7"
+        "@babel/helper-plugin-utils": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -9326,21 +8999,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-transform-object-assign": {
-      "version": "7.16.7",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-transform-object-super": {
       "version": "7.16.7",
       "license": "MIT",
@@ -9438,12 +9096,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx-self": {
-      "version": "7.17.12",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.18.6.tgz",
+      "integrity": "sha512-A0LQGx4+4Jv7u/tWzoJF7alZwnBDQd6cGLh9P+Ttk4dpiL+J5p7NSNv/9tlEFFJDq3kjxOavWmbm6t0Gk+A3Ig==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.17.12"
+        "@babel/helper-plugin-utils": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -9453,12 +9112,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx-source": {
-      "version": "7.16.7",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.18.6.tgz",
+      "integrity": "sha512-utZmlASneDfdaMh0m/WausbjUjEdGrQJz0vFK93d7wD3xf5wBtX219+q6IlCNZeguIcxS2f/CvLZrlLSvSHQXw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.7"
+        "@babel/helper-plugin-utils": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -9785,9 +9445,10 @@
       }
     },
     "node_modules/@babel/register": {
-      "version": "7.17.7",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.18.6.tgz",
+      "integrity": "sha512-tkYtONzaO8rQubZzpBnvZPFcHgh8D9F55IjOsYton4X2IBoyRn2ZSWQqySTZnUn2guZbxbQiAB27hJEbvXamhQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "clone-deep": "^4.0.1",
@@ -9805,8 +9466,9 @@
     },
     "node_modules/@babel/register/node_modules/find-cache-dir": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+      "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "commondir": "^1.0.1",
@@ -9819,8 +9481,9 @@
     },
     "node_modules/@babel/register/node_modules/find-up": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "locate-path": "^3.0.0"
@@ -9831,8 +9494,9 @@
     },
     "node_modules/@babel/register/node_modules/locate-path": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "p-locate": "^3.0.0",
@@ -9844,8 +9508,9 @@
     },
     "node_modules/@babel/register/node_modules/make-dir": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "pify": "^4.0.1",
@@ -9857,8 +9522,9 @@
     },
     "node_modules/@babel/register/node_modules/p-limit": {
       "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "p-try": "^2.0.0"
@@ -9872,8 +9538,9 @@
     },
     "node_modules/@babel/register/node_modules/p-locate": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "p-limit": "^2.0.0"
@@ -9884,8 +9551,9 @@
     },
     "node_modules/@babel/register/node_modules/p-try": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=6"
@@ -9893,8 +9561,9 @@
     },
     "node_modules/@babel/register/node_modules/pify": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=6"
@@ -9902,8 +9571,9 @@
     },
     "node_modules/@babel/register/node_modules/pkg-dir": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+      "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "find-up": "^3.0.0"
@@ -9914,8 +9584,9 @@
     },
     "node_modules/@babel/register/node_modules/semver": {
       "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true,
-      "license": "ISC",
       "peer": true,
       "bin": {
         "semver": "bin/semver"
@@ -13860,66 +13531,24 @@
       "version": "1.0.0-next.21",
       "license": "MIT"
     },
-    "node_modules/@react-native-community/cli-debugger-ui": {
-      "version": "7.0.3",
+    "node_modules/@react-native-community/cli-clean": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-clean/-/cli-clean-8.0.0.tgz",
+      "integrity": "sha512-VY/kwyH5xp6oXiB9bcwa+I9W5k6WR/nX3s85FuMW76hSlgG1UVAGL04uZPwYlSmMZuSOSuoXOaIjJ7wAvQMBpg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "serve-static": "^1.13.1"
-      }
-    },
-    "node_modules/@react-native-community/cli-hermes": {
-      "version": "6.3.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@react-native-community/cli-platform-android": "^6.3.0",
-        "@react-native-community/cli-tools": "^6.2.0",
-        "chalk": "^4.1.2",
-        "hermes-profile-transformer": "^0.0.6",
-        "ip": "^1.1.5"
-      }
-    },
-    "node_modules/@react-native-community/cli-hermes/node_modules/@react-native-community/cli-platform-android": {
-      "version": "6.3.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@react-native-community/cli-tools": "^6.2.0",
+        "@react-native-community/cli-tools": "^8.0.0",
         "chalk": "^4.1.2",
         "execa": "^1.0.0",
-        "fs-extra": "^8.1.0",
-        "glob": "^7.1.3",
-        "jetifier": "^1.6.2",
-        "lodash": "^4.17.15",
-        "logkitty": "^0.7.1",
-        "slash": "^3.0.0",
-        "xmldoc": "^1.1.2"
+        "prompts": "^2.4.0"
       }
     },
-    "node_modules/@react-native-community/cli-hermes/node_modules/@react-native-community/cli-tools": {
-      "version": "6.2.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "appdirsjs": "^1.2.4",
-        "chalk": "^4.1.2",
-        "lodash": "^4.17.15",
-        "mime": "^2.4.1",
-        "node-fetch": "^2.6.0",
-        "open": "^6.2.0",
-        "semver": "^6.3.0",
-        "shell-quote": "1.6.1"
-      }
-    },
-    "node_modules/@react-native-community/cli-hermes/node_modules/ansi-styles": {
+    "node_modules/@react-native-community/cli-clean/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -13931,10 +13560,11 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/@react-native-community/cli-hermes/node_modules/chalk": {
+    "node_modules/@react-native-community/cli-clean/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -13947,10 +13577,11 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/@react-native-community/cli-hermes/node_modules/color-convert": {
+    "node_modules/@react-native-community/cli-clean/node_modules/color-convert": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
@@ -13959,16 +13590,18 @@
         "node": ">=7.0.0"
       }
     },
-    "node_modules/@react-native-community/cli-hermes/node_modules/color-name": {
+    "node_modules/@react-native-community/cli-clean/node_modules/color-name": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
-    "node_modules/@react-native-community/cli-hermes/node_modules/cross-spawn": {
+    "node_modules/@react-native-community/cli-clean/node_modules/cross-spawn": {
       "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "nice-try": "^1.0.4",
@@ -13981,19 +13614,11 @@
         "node": ">=4.8"
       }
     },
-    "node_modules/@react-native-community/cli-hermes/node_modules/cross-spawn/node_modules/semver": {
-      "version": "5.7.1",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/@react-native-community/cli-hermes/node_modules/execa": {
+    "node_modules/@react-native-community/cli-clean/node_modules/execa": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "cross-spawn": "^6.0.0",
@@ -14008,24 +13633,11 @@
         "node": ">=6"
       }
     },
-    "node_modules/@react-native-community/cli-hermes/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/@react-native-community/cli-hermes/node_modules/get-stream": {
+    "node_modules/@react-native-community/cli-clean/node_modules/get-stream": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "pump": "^3.0.0"
@@ -14034,46 +13646,31 @@
         "node": ">=6"
       }
     },
-    "node_modules/@react-native-community/cli-hermes/node_modules/has-flag": {
+    "node_modules/@react-native-community/cli-clean/node_modules/has-flag": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=8"
       }
     },
-    "node_modules/@react-native-community/cli-hermes/node_modules/is-stream": {
+    "node_modules/@react-native-community/cli-clean/node_modules/is-stream": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
-    "node_modules/@react-native-community/cli-hermes/node_modules/is-wsl": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@react-native-community/cli-hermes/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@react-native-community/cli-hermes/node_modules/npm-run-path": {
+    "node_modules/@react-native-community/cli-clean/node_modules/npm-run-path": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "path-key": "^2.0.0"
@@ -14082,31 +13679,31 @@
         "node": ">=4"
       }
     },
-    "node_modules/@react-native-community/cli-hermes/node_modules/open": {
-      "version": "6.4.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "is-wsl": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@react-native-community/cli-hermes/node_modules/path-key": {
+    "node_modules/@react-native-community/cli-clean/node_modules/path-key": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=4"
       }
     },
-    "node_modules/@react-native-community/cli-hermes/node_modules/shebang-command": {
-      "version": "1.2.0",
+    "node_modules/@react-native-community/cli-clean/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true,
-      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/@react-native-community/cli-clean/node_modules/shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+      "dev": true,
       "peer": true,
       "dependencies": {
         "shebang-regex": "^1.0.0"
@@ -14115,31 +13712,21 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/@react-native-community/cli-hermes/node_modules/shebang-regex": {
+    "node_modules/@react-native-community/cli-clean/node_modules/shebang-regex": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
-    "node_modules/@react-native-community/cli-hermes/node_modules/shell-quote": {
-      "version": "1.6.1",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "array-filter": "~0.0.0",
-        "array-map": "~0.0.0",
-        "array-reduce": "~0.0.0",
-        "jsonify": "~0.0.0"
-      }
-    },
-    "node_modules/@react-native-community/cli-hermes/node_modules/supports-color": {
+    "node_modules/@react-native-community/cli-clean/node_modules/supports-color": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -14148,19 +13735,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/@react-native-community/cli-hermes/node_modules/universalify": {
-      "version": "0.1.2",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/@react-native-community/cli-hermes/node_modules/which": {
+    "node_modules/@react-native-community/cli-clean/node_modules/which": {
       "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
-      "license": "ISC",
       "peer": true,
       "dependencies": {
         "isexe": "^2.0.0"
@@ -14169,13 +13748,468 @@
         "which": "bin/which"
       }
     },
-    "node_modules/@react-native-community/cli-platform-android": {
-      "version": "7.0.1",
+    "node_modules/@react-native-community/cli-config": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-config/-/cli-config-8.0.2.tgz",
+      "integrity": "sha512-q0mL6QBzoLDHmlvkAKdgioIsMeyvvgRyu0WVLvT/v5DX6OVRvq4UEULLEY+7/P+760nPBQo4Ou1KqpP/SxmbXA==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@react-native-community/cli-tools": "^7.0.1",
+        "@react-native-community/cli-tools": "^8.0.0",
+        "cosmiconfig": "^5.1.0",
+        "deepmerge": "^3.2.0",
+        "glob": "^7.1.3",
+        "joi": "^17.2.1"
+      }
+    },
+    "node_modules/@react-native-community/cli-config/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@react-native-community/cli-config/node_modules/cosmiconfig": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+      "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "import-fresh": "^2.0.0",
+        "is-directory": "^0.3.1",
+        "js-yaml": "^3.13.1",
+        "parse-json": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@react-native-community/cli-config/node_modules/deepmerge": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.3.0.tgz",
+      "integrity": "sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@react-native-community/cli-config/node_modules/import-fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+      "integrity": "sha512-eZ5H8rcgYazHbKC3PG4ClHNykCSxtAhxSSEM+2mb+7evD2CKF5V7c0dNum7AdpDh0ZdICwZY9sRSn8f+KH96sg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "caller-path": "^2.0.0",
+        "resolve-from": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@react-native-community/cli-config/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@react-native-community/cli-config/node_modules/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@react-native-community/cli-config/node_modules/resolve-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+      "integrity": "sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@react-native-community/cli-debugger-ui": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-8.0.0.tgz",
+      "integrity": "sha512-u2jq06GZwZ9sRERzd9FIgpW6yv4YOW4zz7Ym/B8eSzviLmy3yI/8mxJtvlGW+J8lBsfMcQoqJpqI6Rl1nZy9yQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "serve-static": "^1.13.1"
+      }
+    },
+    "node_modules/@react-native-community/cli-doctor": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-doctor/-/cli-doctor-8.0.2.tgz",
+      "integrity": "sha512-XOimZcBR8n0Ipuk0iXfbZwxrt1r+2fZnskInZRf3SkYrLIKzDLF+ylKbNWJeuMWZSz9lQimo2cI/978bH1JQGw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@react-native-community/cli-config": "^8.0.2",
+        "@react-native-community/cli-platform-ios": "^8.0.2",
+        "@react-native-community/cli-tools": "^8.0.0",
+        "chalk": "^4.1.2",
+        "command-exists": "^1.2.8",
+        "envinfo": "^7.7.2",
+        "execa": "^1.0.0",
+        "hermes-profile-transformer": "^0.0.6",
+        "ip": "^1.1.5",
+        "node-stream-zip": "^1.9.1",
+        "ora": "^5.4.1",
+        "prompts": "^2.4.0",
+        "semver": "^6.3.0",
+        "strip-ansi": "^5.2.0",
+        "sudo-prompt": "^9.0.0",
+        "wcwidth": "^1.0.1"
+      }
+    },
+    "node_modules/@react-native-community/cli-doctor/node_modules/ansi-regex": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@react-native-community/cli-doctor/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@react-native-community/cli-doctor/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@react-native-community/cli-doctor/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@react-native-community/cli-doctor/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@react-native-community/cli-doctor/node_modules/cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "engines": {
+        "node": ">=4.8"
+      }
+    },
+    "node_modules/@react-native-community/cli-doctor/node_modules/cross-spawn/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/@react-native-community/cli-doctor/node_modules/execa": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@react-native-community/cli-doctor/node_modules/get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@react-native-community/cli-doctor/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@react-native-community/cli-doctor/node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@react-native-community/cli-doctor/node_modules/npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "path-key": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@react-native-community/cli-doctor/node_modules/path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@react-native-community/cli-doctor/node_modules/shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@react-native-community/cli-doctor/node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@react-native-community/cli-doctor/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@react-native-community/cli-doctor/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@react-native-community/cli-doctor/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/@react-native-community/cli-hermes": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-8.0.2.tgz",
+      "integrity": "sha512-RZ9uHTf3UFtGTYxq88uENJEdaDB8ab+YPBDn+Li1u78IKwNeL04F0A1A3ab3hYUkG4PEPnL2rkYSlzzNFLOSPQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@react-native-community/cli-platform-android": "^8.0.2",
+        "@react-native-community/cli-tools": "^8.0.0",
+        "chalk": "^4.1.2",
+        "hermes-profile-transformer": "^0.0.6",
+        "ip": "^1.1.5"
+      }
+    },
+    "node_modules/@react-native-community/cli-hermes/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@react-native-community/cli-hermes/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@react-native-community/cli-hermes/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@react-native-community/cli-hermes/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@react-native-community/cli-hermes/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@react-native-community/cli-hermes/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@react-native-community/cli-platform-android": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-8.0.2.tgz",
+      "integrity": "sha512-pAEkt+GULesr8FphTpaNYSmu+O1CPQ2zCXkAg4kRd0WXpq3BsVqomyDWd/eMXTkY/yYQMGl6KilU2p9r/hnfhA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@react-native-community/cli-tools": "^8.0.0",
         "chalk": "^4.1.2",
         "execa": "^1.0.0",
         "fs-extra": "^8.1.0",
@@ -14183,14 +14217,14 @@
         "jetifier": "^1.6.2",
         "lodash": "^4.17.15",
         "logkitty": "^0.7.1",
-        "slash": "^3.0.0",
-        "xmldoc": "^1.1.2"
+        "slash": "^3.0.0"
       }
     },
     "node_modules/@react-native-community/cli-platform-android/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -14204,8 +14238,9 @@
     },
     "node_modules/@react-native-community/cli-platform-android/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -14220,8 +14255,9 @@
     },
     "node_modules/@react-native-community/cli-platform-android/node_modules/color-convert": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
@@ -14232,14 +14268,16 @@
     },
     "node_modules/@react-native-community/cli-platform-android/node_modules/color-name": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/@react-native-community/cli-platform-android/node_modules/cross-spawn": {
       "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "nice-try": "^1.0.4",
@@ -14254,8 +14292,9 @@
     },
     "node_modules/@react-native-community/cli-platform-android/node_modules/execa": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "cross-spawn": "^6.0.0",
@@ -14272,8 +14311,9 @@
     },
     "node_modules/@react-native-community/cli-platform-android/node_modules/fs-extra": {
       "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -14286,8 +14326,9 @@
     },
     "node_modules/@react-native-community/cli-platform-android/node_modules/get-stream": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "pump": "^3.0.0"
@@ -14298,8 +14339,9 @@
     },
     "node_modules/@react-native-community/cli-platform-android/node_modules/has-flag": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=8"
@@ -14307,8 +14349,9 @@
     },
     "node_modules/@react-native-community/cli-platform-android/node_modules/is-stream": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -14316,8 +14359,9 @@
     },
     "node_modules/@react-native-community/cli-platform-android/node_modules/jsonfile": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
@@ -14325,8 +14369,9 @@
     },
     "node_modules/@react-native-community/cli-platform-android/node_modules/npm-run-path": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "path-key": "^2.0.0"
@@ -14337,8 +14382,9 @@
     },
     "node_modules/@react-native-community/cli-platform-android/node_modules/path-key": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=4"
@@ -14346,8 +14392,9 @@
     },
     "node_modules/@react-native-community/cli-platform-android/node_modules/semver": {
       "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true,
-      "license": "ISC",
       "peer": true,
       "bin": {
         "semver": "bin/semver"
@@ -14355,8 +14402,9 @@
     },
     "node_modules/@react-native-community/cli-platform-android/node_modules/shebang-command": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "shebang-regex": "^1.0.0"
@@ -14367,8 +14415,9 @@
     },
     "node_modules/@react-native-community/cli-platform-android/node_modules/shebang-regex": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -14376,8 +14425,9 @@
     },
     "node_modules/@react-native-community/cli-platform-android/node_modules/supports-color": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -14388,8 +14438,9 @@
     },
     "node_modules/@react-native-community/cli-platform-android/node_modules/universalify": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">= 4.0.0"
@@ -14397,8 +14448,9 @@
     },
     "node_modules/@react-native-community/cli-platform-android/node_modules/which": {
       "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
-      "license": "ISC",
       "peer": true,
       "dependencies": {
         "isexe": "^2.0.0"
@@ -14408,26 +14460,27 @@
       }
     },
     "node_modules/@react-native-community/cli-platform-ios": {
-      "version": "7.0.1",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-8.0.2.tgz",
+      "integrity": "sha512-LxWzj6jIZr5Ot893TKFbt0/T3WkVe6pbc/FSTo+TDQq1FQr/Urv16Uqn0AcL4IX2O1g3Qd13d0vtR/Cdpn3VNw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@react-native-community/cli-tools": "^7.0.1",
+        "@react-native-community/cli-tools": "^8.0.0",
         "chalk": "^4.1.2",
         "execa": "^1.0.0",
         "glob": "^7.1.3",
         "js-yaml": "^3.13.1",
         "lodash": "^4.17.15",
         "ora": "^5.4.1",
-        "plist": "^3.0.2",
-        "xcode": "^3.0.0"
+        "plist": "^3.0.2"
       }
     },
     "node_modules/@react-native-community/cli-platform-ios/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -14441,8 +14494,9 @@
     },
     "node_modules/@react-native-community/cli-platform-ios/node_modules/argparse": {
       "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
@@ -14450,8 +14504,9 @@
     },
     "node_modules/@react-native-community/cli-platform-ios/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -14466,8 +14521,9 @@
     },
     "node_modules/@react-native-community/cli-platform-ios/node_modules/color-convert": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
@@ -14478,14 +14534,16 @@
     },
     "node_modules/@react-native-community/cli-platform-ios/node_modules/color-name": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/@react-native-community/cli-platform-ios/node_modules/cross-spawn": {
       "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "nice-try": "^1.0.4",
@@ -14500,8 +14558,9 @@
     },
     "node_modules/@react-native-community/cli-platform-ios/node_modules/execa": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "cross-spawn": "^6.0.0",
@@ -14518,8 +14577,9 @@
     },
     "node_modules/@react-native-community/cli-platform-ios/node_modules/get-stream": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "pump": "^3.0.0"
@@ -14530,8 +14590,9 @@
     },
     "node_modules/@react-native-community/cli-platform-ios/node_modules/has-flag": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=8"
@@ -14539,8 +14600,9 @@
     },
     "node_modules/@react-native-community/cli-platform-ios/node_modules/is-stream": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -14548,8 +14610,9 @@
     },
     "node_modules/@react-native-community/cli-platform-ios/node_modules/js-yaml": {
       "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "argparse": "^1.0.7",
@@ -14561,8 +14624,9 @@
     },
     "node_modules/@react-native-community/cli-platform-ios/node_modules/npm-run-path": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "path-key": "^2.0.0"
@@ -14573,8 +14637,9 @@
     },
     "node_modules/@react-native-community/cli-platform-ios/node_modules/path-key": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=4"
@@ -14582,8 +14647,9 @@
     },
     "node_modules/@react-native-community/cli-platform-ios/node_modules/semver": {
       "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true,
-      "license": "ISC",
       "peer": true,
       "bin": {
         "semver": "bin/semver"
@@ -14591,8 +14657,9 @@
     },
     "node_modules/@react-native-community/cli-platform-ios/node_modules/shebang-command": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "shebang-regex": "^1.0.0"
@@ -14603,8 +14670,9 @@
     },
     "node_modules/@react-native-community/cli-platform-ios/node_modules/shebang-regex": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -14612,8 +14680,9 @@
     },
     "node_modules/@react-native-community/cli-platform-ios/node_modules/supports-color": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -14624,8 +14693,9 @@
     },
     "node_modules/@react-native-community/cli-platform-ios/node_modules/which": {
       "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
-      "license": "ISC",
       "peer": true,
       "dependencies": {
         "isexe": "^2.0.0"
@@ -14635,43 +14705,29 @@
       }
     },
     "node_modules/@react-native-community/cli-plugin-metro": {
-      "version": "7.0.3",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-8.0.0.tgz",
+      "integrity": "sha512-eIowV2ZRbzIWL3RIKVUUSahntXTuAeKzBSsFuhffLZphsV+UdKdtg5ATR9zbq7nsKap4ZseO5DkVqZngUkC7iQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@react-native-community/cli-server-api": "^7.0.3",
-        "@react-native-community/cli-tools": "^6.2.0",
+        "@react-native-community/cli-server-api": "^8.0.0",
+        "@react-native-community/cli-tools": "^8.0.0",
         "chalk": "^4.1.2",
-        "metro": "^0.67.0",
-        "metro-config": "^0.67.0",
-        "metro-core": "^0.67.0",
-        "metro-react-native-babel-transformer": "^0.67.0",
-        "metro-resolver": "^0.67.0",
-        "metro-runtime": "^0.67.0",
+        "metro": "^0.70.1",
+        "metro-config": "^0.70.1",
+        "metro-core": "^0.70.1",
+        "metro-react-native-babel-transformer": "^0.70.1",
+        "metro-resolver": "^0.70.1",
+        "metro-runtime": "^0.70.1",
         "readline": "^1.3.0"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/@react-native-community/cli-tools": {
-      "version": "6.2.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "appdirsjs": "^1.2.4",
-        "chalk": "^4.1.2",
-        "lodash": "^4.17.15",
-        "mime": "^2.4.1",
-        "node-fetch": "^2.6.0",
-        "open": "^6.2.0",
-        "semver": "^6.3.0",
-        "shell-quote": "1.6.1"
       }
     },
     "node_modules/@react-native-community/cli-plugin-metro/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -14685,8 +14741,9 @@
     },
     "node_modules/@react-native-community/cli-plugin-metro/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -14701,8 +14758,9 @@
     },
     "node_modules/@react-native-community/cli-plugin-metro/node_modules/color-convert": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
@@ -14713,56 +14771,26 @@
     },
     "node_modules/@react-native-community/cli-plugin-metro/node_modules/color-name": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/@react-native-community/cli-plugin-metro/node_modules/has-flag": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/is-wsl": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/open": {
-      "version": "6.4.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "is-wsl": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/shell-quote": {
-      "version": "1.6.1",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "array-filter": "~0.0.0",
-        "array-map": "~0.0.0",
-        "array-reduce": "~0.0.0",
-        "jsonify": "~0.0.0"
       }
     },
     "node_modules/@react-native-community/cli-plugin-metro/node_modules/supports-color": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -14772,17 +14800,18 @@
       }
     },
     "node_modules/@react-native-community/cli-server-api": {
-      "version": "7.0.3",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-8.0.0.tgz",
+      "integrity": "sha512-TxUs3sMl9clt7sdv30XETc6VRzyaEli2vDrk3TB5W5o5nSd1PmQdP4ccdGLO/nDRXwOy72QmmXlYWMg1XGU0Gg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@react-native-community/cli-debugger-ui": "^7.0.3",
-        "@react-native-community/cli-tools": "^6.2.0",
+        "@react-native-community/cli-debugger-ui": "^8.0.0",
+        "@react-native-community/cli-tools": "^8.0.0",
         "compression": "^1.7.1",
         "connect": "^3.6.5",
         "errorhandler": "^1.5.0",
-        "nocache": "^2.1.0",
+        "nocache": "^3.0.1",
         "pretty-format": "^26.6.2",
         "serve-static": "^1.13.1",
         "ws": "^7.5.1"
@@ -14790,8 +14819,9 @@
     },
     "node_modules/@react-native-community/cli-server-api/node_modules/@jest/types": {
       "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+      "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -14804,26 +14834,11 @@
         "node": ">= 10.14.2"
       }
     },
-    "node_modules/@react-native-community/cli-server-api/node_modules/@react-native-community/cli-tools": {
-      "version": "6.2.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "appdirsjs": "^1.2.4",
-        "chalk": "^4.1.2",
-        "lodash": "^4.17.15",
-        "mime": "^2.4.1",
-        "node-fetch": "^2.6.0",
-        "open": "^6.2.0",
-        "semver": "^6.3.0",
-        "shell-quote": "1.6.1"
-      }
-    },
     "node_modules/@react-native-community/cli-server-api/node_modules/@types/yargs": {
       "version": "15.0.14",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
+      "integrity": "sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -14831,8 +14846,9 @@
     },
     "node_modules/@react-native-community/cli-server-api/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -14846,8 +14862,9 @@
     },
     "node_modules/@react-native-community/cli-server-api/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -14862,8 +14879,9 @@
     },
     "node_modules/@react-native-community/cli-server-api/node_modules/color-convert": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
@@ -14874,44 +14892,26 @@
     },
     "node_modules/@react-native-community/cli-server-api/node_modules/color-name": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/@react-native-community/cli-server-api/node_modules/has-flag": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@react-native-community/cli-server-api/node_modules/is-wsl": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@react-native-community/cli-server-api/node_modules/open": {
-      "version": "6.4.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "is-wsl": "^1.1.0"
-      },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@react-native-community/cli-server-api/node_modules/pretty-format": {
       "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+      "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@jest/types": "^26.6.2",
@@ -14923,22 +14923,11 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@react-native-community/cli-server-api/node_modules/shell-quote": {
-      "version": "1.6.1",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "array-filter": "~0.0.0",
-        "array-map": "~0.0.0",
-        "array-reduce": "~0.0.0",
-        "jsonify": "~0.0.0"
-      }
-    },
     "node_modules/@react-native-community/cli-server-api/node_modules/supports-color": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -14948,9 +14937,10 @@
       }
     },
     "node_modules/@react-native-community/cli-tools": {
-      "version": "7.0.1",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-8.0.0.tgz",
+      "integrity": "sha512-jA4y8CebrRZaOJFjc5zMOnls4KfHkBl2FUtBZV2vcWuedQHa6JVwo+KO88ta3Ysby3uY0+mrZagZfXk7c0mrBw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "appdirsjs": "^1.2.4",
@@ -14966,8 +14956,9 @@
     },
     "node_modules/@react-native-community/cli-tools/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -14981,8 +14972,9 @@
     },
     "node_modules/@react-native-community/cli-tools/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -14997,8 +14989,9 @@
     },
     "node_modules/@react-native-community/cli-tools/node_modules/color-convert": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
@@ -15009,14 +15002,16 @@
     },
     "node_modules/@react-native-community/cli-tools/node_modules/color-name": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/@react-native-community/cli-tools/node_modules/has-flag": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=8"
@@ -15024,8 +15019,9 @@
     },
     "node_modules/@react-native-community/cli-tools/node_modules/is-wsl": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+      "integrity": "sha512-gfygJYZ2gLTDlmbWMI0CE2MwnFzSN/2SZfkMlItC4K/JBlsWVDB0bO6XhqcY13YXE7iMcAJnzTCJjPiTeJJ0Mw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=4"
@@ -15033,8 +15029,9 @@
     },
     "node_modules/@react-native-community/cli-tools/node_modules/open": {
       "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-6.4.0.tgz",
+      "integrity": "sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "is-wsl": "^1.1.0"
@@ -15045,8 +15042,9 @@
     },
     "node_modules/@react-native-community/cli-tools/node_modules/supports-color": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -15056,108 +15054,13 @@
       }
     },
     "node_modules/@react-native-community/cli-types": {
-      "version": "6.0.0",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-types/-/cli-types-8.0.0.tgz",
+      "integrity": "sha512-1lZS1PEvMlFaN3Se1ksyoFWzMjk+YfKi490GgsqKJln9gvFm8tqVPdnXttI5Uf2DQf3BMse8Bk8dNH4oV6Ewow==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "ora": "^3.4.0"
-      }
-    },
-    "node_modules/@react-native-community/cli-types/node_modules/ansi-regex": {
-      "version": "4.1.1",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@react-native-community/cli-types/node_modules/cli-cursor": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "restore-cursor": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@react-native-community/cli-types/node_modules/log-symbols": {
-      "version": "2.2.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "chalk": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@react-native-community/cli-types/node_modules/mimic-fn": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@react-native-community/cli-types/node_modules/onetime": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "mimic-fn": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@react-native-community/cli-types/node_modules/ora": {
-      "version": "3.4.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "chalk": "^2.4.2",
-        "cli-cursor": "^2.1.0",
-        "cli-spinners": "^2.0.0",
-        "log-symbols": "^2.2.0",
-        "strip-ansi": "^5.2.0",
-        "wcwidth": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@react-native-community/cli-types/node_modules/restore-cursor": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "onetime": "^2.0.0",
-        "signal-exit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@react-native-community/cli-types/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
+        "joi": "^17.2.1"
       }
     },
     "node_modules/@react-native/assets": {
@@ -15168,8 +15071,9 @@
     },
     "node_modules/@react-native/normalize-color": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-color/-/normalize-color-2.0.0.tgz",
+      "integrity": "sha512-Wip/xsc5lw8vsBlmY2MO/gFLp3MvuZ2baBZjDeTjjndMgM0h5sxz7AZR62RDPGgstp8Np7JzjvVqVT7tpFZqsw==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/@react-native/polyfills": {
@@ -17198,8 +17102,9 @@
     },
     "node_modules/absolute-path": {
       "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/absolute-path/-/absolute-path-0.0.0.tgz",
+      "integrity": "sha512-HQiug4c+/s3WOvEnDRxXVmNtSG5s2gJM9r19BTcqjp7BWcE48PB+Y2G6jE65kqI0LpsQeMZygt/b60Gi4KxGyA==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/accepts": {
@@ -17522,8 +17427,9 @@
     },
     "node_modules/ansi-fragments": {
       "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-fragments/-/ansi-fragments-0.2.1.tgz",
+      "integrity": "sha512-DykbNHxuXQwUDRv5ibc2b0x7uw7wmwOGLBUd5RmaQ5z8Lhx19vwvKV+FAsM5rEA6dEcHxX+/Ad5s9eF2k2bB+w==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "colorette": "^1.0.7",
@@ -17533,8 +17439,9 @@
     },
     "node_modules/ansi-fragments/node_modules/ansi-regex": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=6"
@@ -17542,14 +17449,16 @@
     },
     "node_modules/ansi-fragments/node_modules/colorette": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/ansi-fragments/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=4"
@@ -17557,8 +17466,9 @@
     },
     "node_modules/ansi-fragments/node_modules/slice-ansi": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "ansi-styles": "^3.2.0",
@@ -17571,8 +17481,9 @@
     },
     "node_modules/ansi-fragments/node_modules/strip-ansi": {
       "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "ansi-regex": "^4.1.0"
@@ -17637,8 +17548,9 @@
     },
     "node_modules/appdirsjs": {
       "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/appdirsjs/-/appdirsjs-1.2.6.tgz",
+      "integrity": "sha512-D8wJNkqMCeQs3kLasatELsddox/Xqkhp+J07iXGyL54fVN7oc+nmNfYzGuCs1IEP6uBw+TfpuO3JKwc+lECy4w==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/append-transform": {
@@ -17794,12 +17706,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/array-filter": {
-      "version": "0.0.1",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/array-find": {
       "version": "1.0.0",
       "dev": true,
@@ -17831,18 +17737,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/array-map": {
-      "version": "0.0.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/array-reduce": {
-      "version": "0.0.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/array-union": {
       "version": "2.1.0",
@@ -18014,8 +17908,9 @@
     },
     "node_modules/ast-types": {
       "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.14.2.tgz",
+      "integrity": "sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "tslib": "^2.0.1"
@@ -18031,14 +17926,16 @@
     },
     "node_modules/ast-types/node_modules/tslib": {
       "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
       "dev": true,
-      "license": "0BSD",
       "peer": true
     },
     "node_modules/astral-regex": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=4"
@@ -18396,8 +18293,9 @@
     },
     "node_modules/babel-core": {
       "version": "7.0.0-bridge.0",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
+      "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -18697,8 +18595,9 @@
     },
     "node_modules/babel-plugin-syntax-trailing-function-commas": {
       "version": "7.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz",
+      "integrity": "sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/babel-plugin-transform-object-rest-spread": {
@@ -18739,8 +18638,9 @@
     },
     "node_modules/babel-preset-fbjs": {
       "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-fbjs/-/babel-preset-fbjs-3.4.0.tgz",
+      "integrity": "sha512-9ywCsCvo1ojrw0b+XYk7aFvTH6D9064t0RIL1rtMf3nsa02Xw41MS7sZw216Im35xj/UY0PDBQsa1brUDDF1Ow==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/plugin-proposal-class-properties": "^7.0.0",
@@ -18924,15 +18824,6 @@
       },
       "engines": {
         "node": ">= 8.0.0"
-      }
-    },
-    "node_modules/big-integer": {
-      "version": "1.6.51",
-      "dev": true,
-      "license": "Unlicense",
-      "peer": true,
-      "engines": {
-        "node": ">=0.6"
       }
     },
     "node_modules/big.js": {
@@ -19202,27 +19093,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/bplist-creator": {
-      "version": "0.1.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "stream-buffers": "2.2.x"
-      }
-    },
-    "node_modules/bplist-parser": {
-      "version": "0.3.1",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "big-integer": "1.6.x"
-      },
-      "engines": {
-        "node": ">= 5.10.0"
-      }
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "license": "MIT",
@@ -19343,7 +19213,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.0",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.1.tgz",
+      "integrity": "sha512-Nq8MFCSrnJXSc88yliwlzQe3qNe3VntIjhsArW9IJOEPSHNx23FalwApUVbzAWABLhYJJ7y8AynWI/XM8OdfjQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -19354,12 +19226,11 @@
           "url": "https://tidelift.com/funding/github/npm/browserslist"
         }
       ],
-      "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001358",
-        "electron-to-chromium": "^1.4.164",
+        "caniuse-lite": "^1.0.30001359",
+        "electron-to-chromium": "^1.4.172",
         "node-releases": "^2.0.5",
-        "update-browserslist-db": "^1.0.0"
+        "update-browserslist-db": "^1.0.4"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -19759,7 +19630,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001358",
+      "version": "1.0.30001361",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001361.tgz",
+      "integrity": "sha512-ybhCrjNtkFji1/Wto6SSJKkWk6kZgVQsDq5QI83SafsF6FXv2JB4df9eEdH6g8sdGgqTXrFLjAxqBGgYoU3azQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -19769,8 +19642,7 @@
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
         }
-      ],
-      "license": "CC-BY-4.0"
+      ]
     },
     "node_modules/capture-exit": {
       "version": "2.0.0",
@@ -20661,8 +20533,9 @@
     },
     "node_modules/command-exists": {
       "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
+      "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/commander": {
@@ -21182,8 +21055,9 @@
     },
     "node_modules/connect": {
       "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz",
+      "integrity": "sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "debug": "2.6.9",
@@ -21204,8 +21078,9 @@
     },
     "node_modules/connect/node_modules/debug": {
       "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "ms": "2.0.0"
@@ -21213,8 +21088,9 @@
     },
     "node_modules/connect/node_modules/finalhandler": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "debug": "2.6.9",
@@ -21231,14 +21107,16 @@
     },
     "node_modules/connect/node_modules/ms": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/connect/node_modules/on-finished": {
       "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "ee-first": "1.1.1"
@@ -21249,8 +21127,9 @@
     },
     "node_modules/connect/node_modules/statuses": {
       "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">= 0.6"
@@ -22961,8 +22840,9 @@
     },
     "node_modules/denodeify": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz",
+      "integrity": "sha512-KNTihKNmQENUZeKu5fzfpzRqR5S2VMp4gl9RFHiWzj9DfvYQPMJ6XHKNaQxaGCXwPk6y9yme3aUoaiAe+KX+vg==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/depd": {
@@ -22970,17 +22850,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/deprecated-react-native-prop-types": {
-      "version": "2.3.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@react-native/normalize-color": "*",
-        "invariant": "*",
-        "prop-types": "*"
       }
     },
     "node_modules/deprecation": {
@@ -23507,8 +23376,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.164",
-      "license": "ISC"
+      "version": "1.4.174",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.174.tgz",
+      "integrity": "sha512-JER+w+9MV2MBVFOXxP036bLlNOnzbYAWrWU8sNUwoOO69T3w4564WhM5H5atd8VVS8U4vpi0i0kdoYzm1NPQgQ=="
     },
     "node_modules/elegant-spinner": {
       "version": "1.0.1",
@@ -23691,8 +23561,9 @@
     },
     "node_modules/envinfo": {
       "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.8.1.tgz",
+      "integrity": "sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "bin": {
         "envinfo": "dist/cli.js"
@@ -23734,8 +23605,9 @@
     },
     "node_modules/errorhandler": {
       "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.5.1.tgz",
+      "integrity": "sha512-rcOwbfvP1WTViVoUjcfZicVzjhjTuhSMntHh6mW3IrEiyE6mJyXvsToJUJGlGlw/2xU9P5whlWNGlIDVeCiT4A==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "accepts": "~1.3.7",
@@ -25611,17 +25483,6 @@
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/fill-keys": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "is-object": "~1.0.1",
-        "merge-descriptors": "~1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "license": "MIT",
@@ -25804,8 +25665,9 @@
     },
     "node_modules/flow-parser": {
       "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.121.0.tgz",
+      "integrity": "sha512-1gIBiWJNR0tKUNv8gZuk7l9rVX06OuLzY9AoGio7y/JT4V1IZErEMEq2TJS+PFcw/y0RshZ1J/27VfK1UQzYVg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=0.4.0"
@@ -27050,24 +26912,27 @@
       "peer": true
     },
     "node_modules/hermes-estree": {
-      "version": "0.5.0",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.6.0.tgz",
+      "integrity": "sha512-2YTGzJCkhdmT6VuNprWjXnvTvw/3iPNw804oc7yknvQpNKo+vJGZmtvLLCghOZf0OwzKaNAzeIMp71zQbNl09w==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/hermes-parser": {
-      "version": "0.5.0",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.6.0.tgz",
+      "integrity": "sha512-Vf58jBZca2+QBLR9h7B7mdg8oFz2g5ILz1iVouZ5DOrOrAfBmPfJjdjDT8jrO0f+iJ4/hSRrQHqHIjSnTaLUDQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "hermes-estree": "0.5.0"
+        "hermes-estree": "0.6.0"
       }
     },
     "node_modules/hermes-profile-transformer": {
       "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/hermes-profile-transformer/-/hermes-profile-transformer-0.0.6.tgz",
+      "integrity": "sha512-cnN7bQUm65UWOy6cbGcCcZ3rpwW8Q/j4OP5aWRhEry4Z2t2aR1cjrbp0BS+KiBN0smvP1caBgAuxutvyvJILzQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "source-map": "^0.7.3"
@@ -27078,8 +26943,9 @@
     },
     "node_modules/hermes-profile-transformer/node_modules/source-map": {
       "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "peer": true,
       "engines": {
         "node": ">= 8"
@@ -28426,13 +28292,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-object": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-path-cwd": {
@@ -31132,8 +30991,9 @@
     },
     "node_modules/jest-serializer": {
       "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-27.5.1.tgz",
+      "integrity": "sha512-jZCyo6iIxO1aqUxpuBlwTDMkzOAJS4a3eYz3YzgxxVQFwLeSA7Jfq5cbqCY+JLvTDrWirgusI/0KwxKMgrdf7w==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@types/node": "*",
@@ -31530,8 +31390,9 @@
     },
     "node_modules/jetifier": {
       "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/jetifier/-/jetifier-1.6.8.tgz",
+      "integrity": "sha512-3Zi16h6L5tXDRQJTb221cnRoVG9/9OvreLdLU2/ZjRv/GILL+2Cemt0IKvkowwkDpvouAU1DQPOJ7qaiHeIdrw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "bin": {
         "jetifier": "bin/jetify",
@@ -31600,8 +31461,9 @@
     },
     "node_modules/jscodeshift": {
       "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.13.1.tgz",
+      "integrity": "sha512-lGyiEbGOvmMRKgWk4vf+lUrCWO/8YR8sUR3FKF1Cq5fovjZDlIcw3Hu5ppLHAnEXshVffvaM0eyuY/AbOeYpnQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/core": "^7.13.16",
@@ -31633,8 +31495,9 @@
     },
     "node_modules/jscodeshift/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -31648,8 +31511,9 @@
     },
     "node_modules/jscodeshift/node_modules/braces": {
       "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "arr-flatten": "^1.1.0",
@@ -31669,8 +31533,9 @@
     },
     "node_modules/jscodeshift/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -31685,8 +31550,9 @@
     },
     "node_modules/jscodeshift/node_modules/color-convert": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
@@ -31697,14 +31563,16 @@
     },
     "node_modules/jscodeshift/node_modules/color-name": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/jscodeshift/node_modules/fill-range": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "extend-shallow": "^2.0.1",
@@ -31718,8 +31586,9 @@
     },
     "node_modules/jscodeshift/node_modules/has-flag": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=8"
@@ -31727,14 +31596,16 @@
     },
     "node_modules/jscodeshift/node_modules/is-buffer": {
       "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/jscodeshift/node_modules/is-extendable": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "is-plain-object": "^2.0.4"
@@ -31745,8 +31616,9 @@
     },
     "node_modules/jscodeshift/node_modules/is-number": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -31757,8 +31629,9 @@
     },
     "node_modules/jscodeshift/node_modules/is-number/node_modules/kind-of": {
       "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -31769,8 +31642,9 @@
     },
     "node_modules/jscodeshift/node_modules/micromatch": {
       "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "arr-diff": "^4.0.0",
@@ -31793,8 +31667,9 @@
     },
     "node_modules/jscodeshift/node_modules/micromatch/node_modules/extend-shallow": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "assign-symbols": "^1.0.0",
@@ -31806,8 +31681,9 @@
     },
     "node_modules/jscodeshift/node_modules/supports-color": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -31818,8 +31694,9 @@
     },
     "node_modules/jscodeshift/node_modules/to-regex-range": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "is-number": "^3.0.0",
@@ -31831,8 +31708,9 @@
     },
     "node_modules/jscodeshift/node_modules/write-file-atomic": {
       "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
       "dev": true,
-      "license": "ISC",
       "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.11",
@@ -32057,12 +31935,6 @@
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
-    },
-    "node_modules/jsonify": {
-      "version": "0.0.0",
-      "dev": true,
-      "license": "Public Domain",
-      "peer": true
     },
     "node_modules/jsonparse": {
       "version": "1.3.1",
@@ -32316,8 +32188,9 @@
     },
     "node_modules/klaw": {
       "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+      "integrity": "sha512-TED5xi9gGQjGpNnvRWknrwAB1eL5GciPfVFOt3Vk1OJCVDQbzuSfrF3hkUQKlsgKrG1F+0t5W0m+Fje1jIt8rw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.9"
@@ -33001,8 +32874,9 @@
     },
     "node_modules/lodash.throttle": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/lodash.trimstart": {
@@ -33394,8 +33268,9 @@
     },
     "node_modules/logkitty": {
       "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/logkitty/-/logkitty-0.7.1.tgz",
+      "integrity": "sha512-/3ER20CTTbahrCrpYfPn7Xavv9diBROZpoXGVZDWMw4b/X4uuUwAC0ki85tgsdMRONURyIJbcOvS94QsUBYPbQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "ansi-fragments": "^0.2.1",
@@ -33408,8 +33283,9 @@
     },
     "node_modules/logkitty/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -33423,8 +33299,9 @@
     },
     "node_modules/logkitty/node_modules/camelcase": {
       "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=6"
@@ -33432,8 +33309,9 @@
     },
     "node_modules/logkitty/node_modules/cliui": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
       "dev": true,
-      "license": "ISC",
       "peer": true,
       "dependencies": {
         "string-width": "^4.2.0",
@@ -33443,8 +33321,9 @@
     },
     "node_modules/logkitty/node_modules/color-convert": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
@@ -33455,20 +33334,23 @@
     },
     "node_modules/logkitty/node_modules/color-name": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/logkitty/node_modules/emoji-regex": {
       "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/logkitty/node_modules/find-up": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "locate-path": "^5.0.0",
@@ -33480,8 +33362,9 @@
     },
     "node_modules/logkitty/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=8"
@@ -33489,8 +33372,9 @@
     },
     "node_modules/logkitty/node_modules/locate-path": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "p-locate": "^4.1.0"
@@ -33501,8 +33385,9 @@
     },
     "node_modules/logkitty/node_modules/p-limit": {
       "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "p-try": "^2.0.0"
@@ -33516,8 +33401,9 @@
     },
     "node_modules/logkitty/node_modules/p-locate": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "p-limit": "^2.2.0"
@@ -33528,8 +33414,9 @@
     },
     "node_modules/logkitty/node_modules/p-try": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=6"
@@ -33537,8 +33424,9 @@
     },
     "node_modules/logkitty/node_modules/path-exists": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=8"
@@ -33546,8 +33434,9 @@
     },
     "node_modules/logkitty/node_modules/string-width": {
       "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -33560,8 +33449,9 @@
     },
     "node_modules/logkitty/node_modules/wrap-ansi": {
       "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -33574,14 +33464,16 @@
     },
     "node_modules/logkitty/node_modules/y18n": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "dev": true,
-      "license": "ISC",
       "peer": true
     },
     "node_modules/logkitty/node_modules/yargs": {
       "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "cliui": "^6.0.0",
@@ -33602,8 +33494,9 @@
     },
     "node_modules/logkitty/node_modules/yargs-parser": {
       "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
       "dev": true,
-      "license": "ISC",
       "peer": true,
       "dependencies": {
         "camelcase": "^5.0.0",
@@ -33954,6 +33847,13 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/memoizee": {
       "version": "0.4.15",
       "dev": true,
@@ -34113,9 +34013,10 @@
       }
     },
     "node_modules/metro": {
-      "version": "0.67.0",
+      "version": "0.70.3",
+      "resolved": "https://registry.npmjs.org/metro/-/metro-0.70.3.tgz",
+      "integrity": "sha512-uEWS7xg8oTetQDABYNtsyeUjdLhH3KAvLFpaFFoJqUpOk2A3iygszdqmjobFl6W4zrvKDJS+XxdMR1roYvUhTw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
@@ -34127,7 +34028,7 @@
         "@babel/types": "^7.0.0",
         "absolute-path": "^0.0.0",
         "accepts": "^1.3.7",
-        "async": "^2.4.0",
+        "async": "^3.2.2",
         "chalk": "^4.0.0",
         "ci-info": "^2.0.0",
         "connect": "^3.6.5",
@@ -34135,30 +34036,29 @@
         "denodeify": "^1.2.1",
         "error-stack-parser": "^2.0.6",
         "fs-extra": "^1.0.0",
-        "graceful-fs": "^4.1.3",
-        "hermes-parser": "0.5.0",
+        "graceful-fs": "^4.2.4",
+        "hermes-parser": "0.6.0",
         "image-size": "^0.6.0",
         "invariant": "^2.2.4",
         "jest-haste-map": "^27.3.1",
-        "jest-worker": "^26.0.0",
+        "jest-worker": "^27.2.0",
         "lodash.throttle": "^4.1.1",
-        "metro-babel-transformer": "0.67.0",
-        "metro-cache": "0.67.0",
-        "metro-cache-key": "0.67.0",
-        "metro-config": "0.67.0",
-        "metro-core": "0.67.0",
-        "metro-hermes-compiler": "0.67.0",
-        "metro-inspector-proxy": "0.67.0",
-        "metro-minify-uglify": "0.67.0",
-        "metro-react-native-babel-preset": "0.67.0",
-        "metro-resolver": "0.67.0",
-        "metro-runtime": "0.67.0",
-        "metro-source-map": "0.67.0",
-        "metro-symbolicate": "0.67.0",
-        "metro-transform-plugins": "0.67.0",
-        "metro-transform-worker": "0.67.0",
+        "metro-babel-transformer": "0.70.3",
+        "metro-cache": "0.70.3",
+        "metro-cache-key": "0.70.3",
+        "metro-config": "0.70.3",
+        "metro-core": "0.70.3",
+        "metro-hermes-compiler": "0.70.3",
+        "metro-inspector-proxy": "0.70.3",
+        "metro-minify-uglify": "0.70.3",
+        "metro-react-native-babel-preset": "0.70.3",
+        "metro-resolver": "0.70.3",
+        "metro-runtime": "0.70.3",
+        "metro-source-map": "0.70.3",
+        "metro-symbolicate": "0.70.3",
+        "metro-transform-plugins": "0.70.3",
+        "metro-transform-worker": "0.70.3",
         "mime-types": "^2.1.27",
-        "mkdirp": "^0.5.1",
         "node-fetch": "^2.2.0",
         "nullthrows": "^1.1.1",
         "rimraf": "^2.5.4",
@@ -34175,38 +34075,41 @@
       }
     },
     "node_modules/metro-babel-transformer": {
-      "version": "0.67.0",
+      "version": "0.70.3",
+      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.70.3.tgz",
+      "integrity": "sha512-bWhZRMn+mIOR/s3BDpFevWScz9sV8FGktVfMlF1eJBLoX24itHDbXvTktKBYi38PWIKcHedh6THSFpJogfuwNA==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/core": "^7.14.0",
-        "hermes-parser": "0.5.0",
-        "metro-source-map": "0.67.0",
+        "hermes-parser": "0.6.0",
+        "metro-source-map": "0.70.3",
         "nullthrows": "^1.1.1"
       }
     },
     "node_modules/metro-cache": {
-      "version": "0.67.0",
+      "version": "0.70.3",
+      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.70.3.tgz",
+      "integrity": "sha512-iCix/+z812fUqa6KlOxaTkY6LQQDoXIe/VljXkGIvpygSCmYyhjQpfQVZEVVPezFmUBYXNdabdQ6cYx6JX3yMg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "metro-core": "0.67.0",
-        "mkdirp": "^0.5.1",
+        "metro-core": "0.70.3",
         "rimraf": "^2.5.4"
       }
     },
     "node_modules/metro-cache-key": {
-      "version": "0.67.0",
+      "version": "0.70.3",
+      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.70.3.tgz",
+      "integrity": "sha512-0zpw+IcpM3hmGd5sKMdxNv3sbOIUYnMUvx1/yaM6vNRReSPmOLX0bP8fYf3CGgk8NEreZ1OHbVsuw7bdKt40Mw==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/metro-cache/node_modules/rimraf": {
       "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "dev": true,
-      "license": "ISC",
       "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
@@ -34216,23 +34119,25 @@
       }
     },
     "node_modules/metro-config": {
-      "version": "0.67.0",
+      "version": "0.70.3",
+      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.70.3.tgz",
+      "integrity": "sha512-SSCDjSTygoCgzoj61DdrBeJzZDRwQxUEfcgc6t6coxWSExXNR4mOngz0q4SAam49Bmjq9J2Jft6qUKnUTPrRgA==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "cosmiconfig": "^5.0.5",
         "jest-validate": "^26.5.2",
-        "metro": "0.67.0",
-        "metro-cache": "0.67.0",
-        "metro-core": "0.67.0",
-        "metro-runtime": "0.67.0"
+        "metro": "0.70.3",
+        "metro-cache": "0.70.3",
+        "metro-core": "0.70.3",
+        "metro-runtime": "0.70.3"
       }
     },
     "node_modules/metro-config/node_modules/@jest/types": {
       "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+      "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -34247,8 +34152,9 @@
     },
     "node_modules/metro-config/node_modules/@types/yargs": {
       "version": "15.0.14",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
+      "integrity": "sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -34256,8 +34162,9 @@
     },
     "node_modules/metro-config/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -34271,8 +34178,9 @@
     },
     "node_modules/metro-config/node_modules/argparse": {
       "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
@@ -34280,8 +34188,9 @@
     },
     "node_modules/metro-config/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -34296,8 +34205,9 @@
     },
     "node_modules/metro-config/node_modules/color-convert": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
@@ -34308,14 +34218,16 @@
     },
     "node_modules/metro-config/node_modules/color-name": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/metro-config/node_modules/cosmiconfig": {
       "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+      "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "import-fresh": "^2.0.0",
@@ -34329,8 +34241,9 @@
     },
     "node_modules/metro-config/node_modules/has-flag": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=8"
@@ -34338,8 +34251,9 @@
     },
     "node_modules/metro-config/node_modules/import-fresh": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+      "integrity": "sha512-eZ5H8rcgYazHbKC3PG4ClHNykCSxtAhxSSEM+2mb+7evD2CKF5V7c0dNum7AdpDh0ZdICwZY9sRSn8f+KH96sg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "caller-path": "^2.0.0",
@@ -34351,8 +34265,9 @@
     },
     "node_modules/metro-config/node_modules/jest-get-type": {
       "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+      "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">= 10.14.2"
@@ -34360,8 +34275,9 @@
     },
     "node_modules/metro-config/node_modules/jest-validate": {
       "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.6.2.tgz",
+      "integrity": "sha512-NEYZ9Aeyj0i5rQqbq+tpIOom0YS1u2MVu6+euBsvpgIme+FOfRmoC4R5p0JiAUpaFvFy24xgrpMknarR/93XjQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@jest/types": "^26.6.2",
@@ -34377,8 +34293,9 @@
     },
     "node_modules/metro-config/node_modules/js-yaml": {
       "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "argparse": "^1.0.7",
@@ -34390,8 +34307,9 @@
     },
     "node_modules/metro-config/node_modules/parse-json": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "error-ex": "^1.3.1",
@@ -34403,8 +34321,9 @@
     },
     "node_modules/metro-config/node_modules/pretty-format": {
       "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+      "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@jest/types": "^26.6.2",
@@ -34418,8 +34337,9 @@
     },
     "node_modules/metro-config/node_modules/resolve-from": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+      "integrity": "sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=4"
@@ -34427,8 +34347,9 @@
     },
     "node_modules/metro-config/node_modules/supports-color": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -34438,20 +34359,22 @@
       }
     },
     "node_modules/metro-core": {
-      "version": "0.67.0",
+      "version": "0.70.3",
+      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.70.3.tgz",
+      "integrity": "sha512-NzfHB/w5R7yLaOeU1tzPTbBzCRsYSvpKJkLMP0yudszKZzIAZqNdjoEJ9GZ688Wi0ynZxcU0BxukXh4my80ZBw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "jest-haste-map": "^27.3.1",
         "lodash.throttle": "^4.1.1",
-        "metro-resolver": "0.67.0"
+        "metro-resolver": "0.70.3"
       }
     },
     "node_modules/metro-core/node_modules/@jest/types": {
       "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.5.1.tgz",
+      "integrity": "sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -34466,8 +34389,9 @@
     },
     "node_modules/metro-core/node_modules/@types/yargs": {
       "version": "16.0.4",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+      "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -34475,8 +34399,9 @@
     },
     "node_modules/metro-core/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -34490,8 +34415,9 @@
     },
     "node_modules/metro-core/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -34506,8 +34432,9 @@
     },
     "node_modules/metro-core/node_modules/color-convert": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
@@ -34518,14 +34445,16 @@
     },
     "node_modules/metro-core/node_modules/color-name": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/metro-core/node_modules/has-flag": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=8"
@@ -34533,8 +34462,9 @@
     },
     "node_modules/metro-core/node_modules/jest-haste-map": {
       "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-27.5.1.tgz",
+      "integrity": "sha512-7GgkZ4Fw4NFbMSDSpZwXeBiIbx+t/46nJ2QitkOjvwPYyZmqttu2TDSimMHP1EkPOi4xUZAN1doE5Vd25H4Jng==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@jest/types": "^27.5.1",
@@ -34559,8 +34489,9 @@
     },
     "node_modules/metro-core/node_modules/jest-regex-util": {
       "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-27.5.1.tgz",
+      "integrity": "sha512-4bfKq2zie+x16okqDXjXn9ql2B0dScQu+vcwe4TvFVhkVyuWLqpZrZtXxLLWoXYgn0E87I6r6GRYHF7wFZBUvg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
@@ -34568,8 +34499,9 @@
     },
     "node_modules/metro-core/node_modules/jest-util": {
       "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.5.1.tgz",
+      "integrity": "sha512-Kv2o/8jNvX1MQ0KGtw480E/w4fBCDOnH6+6DmeKi6LZUIlKA5kwY0YNdlzaWTiVgxqAqik11QyxDOKk543aKXw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@jest/types": "^27.5.1",
@@ -34585,8 +34517,9 @@
     },
     "node_modules/metro-core/node_modules/supports-color": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -34596,15 +34529,17 @@
       }
     },
     "node_modules/metro-hermes-compiler": {
-      "version": "0.67.0",
+      "version": "0.70.3",
+      "resolved": "https://registry.npmjs.org/metro-hermes-compiler/-/metro-hermes-compiler-0.70.3.tgz",
+      "integrity": "sha512-W6WttLi4E72JL/NyteQ84uxYOFMibe0PUr9aBKuJxxfCq6QRnJKOVcNY0NLW0He2tneXGk+8ZsNz8c0flEvYqg==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/metro-inspector-proxy": {
-      "version": "0.67.0",
+      "version": "0.70.3",
+      "resolved": "https://registry.npmjs.org/metro-inspector-proxy/-/metro-inspector-proxy-0.70.3.tgz",
+      "integrity": "sha512-qQoNdPGrmyoJSWYkxSDpTaAI8xyqVdNDVVj9KRm1PG8niSuYmrCCFGLLFsMvkVYwsCWUGHoGBx0UoAzVp14ejw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "connect": "^3.6.5",
@@ -34618,8 +34553,9 @@
     },
     "node_modules/metro-inspector-proxy/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -34633,8 +34569,9 @@
     },
     "node_modules/metro-inspector-proxy/node_modules/camelcase": {
       "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=6"
@@ -34642,8 +34579,9 @@
     },
     "node_modules/metro-inspector-proxy/node_modules/cliui": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
       "dev": true,
-      "license": "ISC",
       "peer": true,
       "dependencies": {
         "string-width": "^4.2.0",
@@ -34653,8 +34591,9 @@
     },
     "node_modules/metro-inspector-proxy/node_modules/color-convert": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
@@ -34665,14 +34604,16 @@
     },
     "node_modules/metro-inspector-proxy/node_modules/color-name": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/metro-inspector-proxy/node_modules/debug": {
       "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "ms": "2.0.0"
@@ -34680,14 +34621,16 @@
     },
     "node_modules/metro-inspector-proxy/node_modules/emoji-regex": {
       "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/metro-inspector-proxy/node_modules/find-up": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "locate-path": "^5.0.0",
@@ -34699,8 +34642,9 @@
     },
     "node_modules/metro-inspector-proxy/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=8"
@@ -34708,8 +34652,9 @@
     },
     "node_modules/metro-inspector-proxy/node_modules/locate-path": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "p-locate": "^4.1.0"
@@ -34720,14 +34665,16 @@
     },
     "node_modules/metro-inspector-proxy/node_modules/ms": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/metro-inspector-proxy/node_modules/p-limit": {
       "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "p-try": "^2.0.0"
@@ -34741,8 +34688,9 @@
     },
     "node_modules/metro-inspector-proxy/node_modules/p-locate": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "p-limit": "^2.2.0"
@@ -34753,8 +34701,9 @@
     },
     "node_modules/metro-inspector-proxy/node_modules/p-try": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=6"
@@ -34762,8 +34711,9 @@
     },
     "node_modules/metro-inspector-proxy/node_modules/path-exists": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=8"
@@ -34771,8 +34721,9 @@
     },
     "node_modules/metro-inspector-proxy/node_modules/string-width": {
       "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -34785,8 +34736,9 @@
     },
     "node_modules/metro-inspector-proxy/node_modules/wrap-ansi": {
       "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -34799,14 +34751,16 @@
     },
     "node_modules/metro-inspector-proxy/node_modules/y18n": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "dev": true,
-      "license": "ISC",
       "peer": true
     },
     "node_modules/metro-inspector-proxy/node_modules/yargs": {
       "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "cliui": "^6.0.0",
@@ -34827,8 +34781,9 @@
     },
     "node_modules/metro-inspector-proxy/node_modules/yargs-parser": {
       "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
       "dev": true,
-      "license": "ISC",
       "peer": true,
       "dependencies": {
         "camelcase": "^5.0.0",
@@ -34839,21 +34794,24 @@
       }
     },
     "node_modules/metro-minify-uglify": {
-      "version": "0.67.0",
+      "version": "0.70.3",
+      "resolved": "https://registry.npmjs.org/metro-minify-uglify/-/metro-minify-uglify-0.70.3.tgz",
+      "integrity": "sha512-oHyjV9WDqOlDE1FPtvs6tIjjeY/oP1PNUPYL1wqyYtqvjN+zzAOrcbsAAL1sv+WARaeiMsWkF2bwtNo+Hghoog==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "uglify-es": "^3.1.9"
       }
     },
     "node_modules/metro-react-native-babel-preset": {
-      "version": "0.67.0",
+      "version": "0.70.3",
+      "resolved": "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.70.3.tgz",
+      "integrity": "sha512-4Nxc1zEiHEu+GTdEMEsHnRgfaBkg8f/Td3+FcQ8NTSvs+xL3LBrQy6N07idWSQZHIdGFf+tTHvRfSIWLD8u8Tg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/core": "^7.14.0",
+        "@babel/plugin-proposal-async-generator-functions": "^7.0.0",
         "@babel/plugin-proposal-class-properties": "^7.0.0",
         "@babel/plugin-proposal-export-default-from": "^7.0.0",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
@@ -34873,17 +34831,15 @@
         "@babel/plugin-transform-destructuring": "^7.0.0",
         "@babel/plugin-transform-exponentiation-operator": "^7.0.0",
         "@babel/plugin-transform-flow-strip-types": "^7.0.0",
-        "@babel/plugin-transform-for-of": "^7.0.0",
         "@babel/plugin-transform-function-name": "^7.0.0",
         "@babel/plugin-transform-literals": "^7.0.0",
         "@babel/plugin-transform-modules-commonjs": "^7.0.0",
-        "@babel/plugin-transform-object-assign": "^7.0.0",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.0.0",
         "@babel/plugin-transform-parameters": "^7.0.0",
         "@babel/plugin-transform-react-display-name": "^7.0.0",
         "@babel/plugin-transform-react-jsx": "^7.0.0",
         "@babel/plugin-transform-react-jsx-self": "^7.0.0",
         "@babel/plugin-transform-react-jsx-source": "^7.0.0",
-        "@babel/plugin-transform-regenerator": "^7.0.0",
         "@babel/plugin-transform-runtime": "^7.0.0",
         "@babel/plugin-transform-shorthand-properties": "^7.0.0",
         "@babel/plugin-transform-spread": "^7.0.0",
@@ -34900,25 +34856,27 @@
     },
     "node_modules/metro-react-native-babel-preset/node_modules/react-refresh": {
       "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.4.3.tgz",
+      "integrity": "sha512-Hwln1VNuGl/6bVwnd0Xdn1e84gT/8T9aYNL+HAKDArLCS7LWjwr7StE30IEYbIkx0Vi3vs+coQxe+SQDbGbbpA==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/metro-react-native-babel-transformer": {
-      "version": "0.67.0",
+      "version": "0.70.3",
+      "resolved": "https://registry.npmjs.org/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.70.3.tgz",
+      "integrity": "sha512-WKBU6S/G50j9cfmFM4k4oRYprd8u3qjleD4so1E2zbTNILg+gYla7ZFGCAvi2G0ZcqS2XuGCR375c2hF6VVvwg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/core": "^7.14.0",
         "babel-preset-fbjs": "^3.4.0",
-        "hermes-parser": "0.5.0",
-        "metro-babel-transformer": "0.67.0",
-        "metro-react-native-babel-preset": "0.67.0",
-        "metro-source-map": "0.67.0",
+        "hermes-parser": "0.6.0",
+        "metro-babel-transformer": "0.70.3",
+        "metro-react-native-babel-preset": "0.70.3",
+        "metro-source-map": "0.70.3",
         "nullthrows": "^1.1.1"
       },
       "peerDependencies": {
@@ -34926,53 +34884,61 @@
       }
     },
     "node_modules/metro-resolver": {
-      "version": "0.67.0",
+      "version": "0.70.3",
+      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.70.3.tgz",
+      "integrity": "sha512-5Pc5S/Gs4RlLbziuIWtvtFd9GRoILlaRC8RZDVq5JZWcWHywKy/PjNmOBNhpyvtRlzpJfy/ssIfLhu8zINt1Mw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "absolute-path": "^0.0.0"
       }
     },
     "node_modules/metro-runtime": {
-      "version": "0.67.0",
+      "version": "0.70.3",
+      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.70.3.tgz",
+      "integrity": "sha512-22xU7UdXZacniTIDZgN2EYtmfau2pPyh97Dcs+cWrLcJYgfMKjWBtesnDcUAQy3PHekDYvBdJZkoQUeskYTM+w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.0.0"
+      }
     },
     "node_modules/metro-source-map": {
-      "version": "0.67.0",
+      "version": "0.70.3",
+      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.70.3.tgz",
+      "integrity": "sha512-zsYtZGrwRbbGEFHtmMqqeCH9K9aTGNVPsurMOWCUeQA3VGyVGXPGtLMC+CdAM9jLpUyg6jw2xh0esxi+tYH7Uw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/traverse": "^7.14.0",
         "@babel/types": "^7.0.0",
         "invariant": "^2.2.4",
-        "metro-symbolicate": "0.67.0",
+        "metro-symbolicate": "0.70.3",
         "nullthrows": "^1.1.1",
-        "ob1": "0.67.0",
+        "ob1": "0.70.3",
         "source-map": "^0.5.6",
         "vlq": "^1.0.0"
       }
     },
     "node_modules/metro-source-map/node_modules/source-map": {
       "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/metro-symbolicate": {
-      "version": "0.67.0",
+      "version": "0.70.3",
+      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.70.3.tgz",
+      "integrity": "sha512-JTYkF1dpeDUssQ84juE1ycnhHki2ylJBBdJE1JHtfu5oC+z1ElDbBdPHq90Uvt8HbRov/ZAnxvv7Zy6asS+WCA==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "invariant": "^2.2.4",
-        "metro-source-map": "0.67.0",
+        "metro-source-map": "0.70.3",
         "nullthrows": "^1.1.1",
         "source-map": "^0.5.6",
         "through2": "^2.0.1",
@@ -34987,17 +34953,19 @@
     },
     "node_modules/metro-symbolicate/node_modules/source-map": {
       "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/metro-transform-plugins": {
-      "version": "0.67.0",
+      "version": "0.70.3",
+      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.70.3.tgz",
+      "integrity": "sha512-dQRIJoTkWZN2IVS2KzgS1hs7ZdHDX3fS3esfifPkqFAEwHiLctCf0EsPgIknp0AjMLvmGWfSLJigdRB/dc0ASw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/core": "^7.14.0",
@@ -35008,9 +34976,10 @@
       }
     },
     "node_modules/metro-transform-worker": {
-      "version": "0.67.0",
+      "version": "0.70.3",
+      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.70.3.tgz",
+      "integrity": "sha512-MtVVsnHhhBOp9GRLCdAb2mD1dTCsIzT4+m34KMRdBDCEbDIb90YafT5prpU8qbj5uKd0o2FOQdrJ5iy5zQilHw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/core": "^7.14.0",
@@ -35018,20 +34987,21 @@
         "@babel/parser": "^7.14.0",
         "@babel/types": "^7.0.0",
         "babel-preset-fbjs": "^3.4.0",
-        "metro": "0.67.0",
-        "metro-babel-transformer": "0.67.0",
-        "metro-cache": "0.67.0",
-        "metro-cache-key": "0.67.0",
-        "metro-hermes-compiler": "0.67.0",
-        "metro-source-map": "0.67.0",
-        "metro-transform-plugins": "0.67.0",
+        "metro": "0.70.3",
+        "metro-babel-transformer": "0.70.3",
+        "metro-cache": "0.70.3",
+        "metro-cache-key": "0.70.3",
+        "metro-hermes-compiler": "0.70.3",
+        "metro-source-map": "0.70.3",
+        "metro-transform-plugins": "0.70.3",
         "nullthrows": "^1.1.1"
       }
     },
     "node_modules/metro/node_modules/@jest/types": {
       "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.5.1.tgz",
+      "integrity": "sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -35046,8 +35016,9 @@
     },
     "node_modules/metro/node_modules/@types/yargs": {
       "version": "16.0.4",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+      "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -35055,8 +35026,9 @@
     },
     "node_modules/metro/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -35068,19 +35040,11 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/metro/node_modules/async": {
-      "version": "2.6.4",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "lodash": "^4.17.14"
-      }
-    },
     "node_modules/metro/node_modules/camelcase": {
       "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=6"
@@ -35088,8 +35052,9 @@
     },
     "node_modules/metro/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -35104,14 +35069,16 @@
     },
     "node_modules/metro/node_modules/ci-info": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/metro/node_modules/cliui": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
       "dev": true,
-      "license": "ISC",
       "peer": true,
       "dependencies": {
         "string-width": "^4.2.0",
@@ -35121,8 +35088,9 @@
     },
     "node_modules/metro/node_modules/color-convert": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
@@ -35133,14 +35101,16 @@
     },
     "node_modules/metro/node_modules/color-name": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/metro/node_modules/debug": {
       "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "ms": "2.0.0"
@@ -35148,14 +35118,16 @@
     },
     "node_modules/metro/node_modules/emoji-regex": {
       "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/metro/node_modules/find-up": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "locate-path": "^5.0.0",
@@ -35167,8 +35139,9 @@
     },
     "node_modules/metro/node_modules/fs-extra": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+      "integrity": "sha512-VerQV6vEKuhDWD2HGOybV6v5I73syoc/cXAbKlgTC7M/oFVEtklWlp9QH2Ijw3IaWDOQcMkldSPa7zXy79Z/UQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
@@ -35178,8 +35151,9 @@
     },
     "node_modules/metro/node_modules/has-flag": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=8"
@@ -35187,8 +35161,9 @@
     },
     "node_modules/metro/node_modules/image-size": {
       "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.6.3.tgz",
+      "integrity": "sha512-47xSUiQioGaB96nqtp5/q55m0aBQSQdyIloMOc/x+QVTDZLNmXE892IIDrJ0hM1A5vcNUDD5tDffkSP5lCaIIA==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "bin": {
         "image-size": "bin/image-size.js"
@@ -35199,8 +35174,9 @@
     },
     "node_modules/metro/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=8"
@@ -35208,8 +35184,9 @@
     },
     "node_modules/metro/node_modules/jest-haste-map": {
       "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-27.5.1.tgz",
+      "integrity": "sha512-7GgkZ4Fw4NFbMSDSpZwXeBiIbx+t/46nJ2QitkOjvwPYyZmqttu2TDSimMHP1EkPOi4xUZAN1doE5Vd25H4Jng==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@jest/types": "^27.5.1",
@@ -35232,39 +35209,11 @@
         "fsevents": "^2.3.2"
       }
     },
-    "node_modules/metro/node_modules/jest-haste-map/node_modules/jest-worker": {
-      "version": "27.5.1",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/node": "*",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      }
-    },
-    "node_modules/metro/node_modules/jest-haste-map/node_modules/supports-color": {
-      "version": "8.1.1",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
     "node_modules/metro/node_modules/jest-regex-util": {
       "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-27.5.1.tgz",
+      "integrity": "sha512-4bfKq2zie+x16okqDXjXn9ql2B0dScQu+vcwe4TvFVhkVyuWLqpZrZtXxLLWoXYgn0E87I6r6GRYHF7wFZBUvg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
@@ -35272,8 +35221,9 @@
     },
     "node_modules/metro/node_modules/jest-util": {
       "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.5.1.tgz",
+      "integrity": "sha512-Kv2o/8jNvX1MQ0KGtw480E/w4fBCDOnH6+6DmeKi6LZUIlKA5kwY0YNdlzaWTiVgxqAqik11QyxDOKk543aKXw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@jest/types": "^27.5.1",
@@ -35289,28 +35239,16 @@
     },
     "node_modules/metro/node_modules/jest-util/node_modules/ci-info": {
       "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.2.tgz",
+      "integrity": "sha512-xmDt/QIAdeZ9+nfdPsaBCpMvHNLFiLdjj59qjqn+6iPe6YmHGQ35sBnQ8uslRBXFmXkiZQOJRjvQeoGppoTjjg==",
       "dev": true,
-      "license": "MIT",
       "peer": true
-    },
-    "node_modules/metro/node_modules/jest-worker": {
-      "version": "26.6.2",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/node": "*",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      }
     },
     "node_modules/metro/node_modules/jsonfile": {
       "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "integrity": "sha512-PKllAqbgLgxHaj8TElYymKCAgrASebJrWpTnEkOaTowt23VKXXN0sUeriJ+eh7y6ufb/CC5ap11pz71/cM0hUw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
@@ -35318,8 +35256,9 @@
     },
     "node_modules/metro/node_modules/locate-path": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "p-locate": "^4.1.0"
@@ -35330,14 +35269,16 @@
     },
     "node_modules/metro/node_modules/ms": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/metro/node_modules/p-limit": {
       "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "p-try": "^2.0.0"
@@ -35351,8 +35292,9 @@
     },
     "node_modules/metro/node_modules/p-locate": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "p-limit": "^2.2.0"
@@ -35363,8 +35305,9 @@
     },
     "node_modules/metro/node_modules/p-try": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=6"
@@ -35372,8 +35315,9 @@
     },
     "node_modules/metro/node_modules/path-exists": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=8"
@@ -35381,8 +35325,9 @@
     },
     "node_modules/metro/node_modules/rimraf": {
       "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "dev": true,
-      "license": "ISC",
       "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
@@ -35393,8 +35338,9 @@
     },
     "node_modules/metro/node_modules/source-map": {
       "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -35402,8 +35348,9 @@
     },
     "node_modules/metro/node_modules/string-width": {
       "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -35416,8 +35363,9 @@
     },
     "node_modules/metro/node_modules/supports-color": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -35428,11 +35376,12 @@
     },
     "node_modules/metro/node_modules/temp": {
       "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
+      "integrity": "sha512-jtnWJs6B1cZlHs9wPG7BrowKxZw/rf6+UpGAkr8AaYmiTyTO7zQlLoST8zx/8TcUPnZmeBoB+H8ARuHZaSijVw==",
       "dev": true,
       "engines": [
         "node >=0.8.0"
       ],
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "os-tmpdir": "^1.0.0",
@@ -35441,8 +35390,9 @@
     },
     "node_modules/metro/node_modules/temp/node_modules/rimraf": {
       "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+      "integrity": "sha512-R5KMKHnPAQaZMqLOsyuyUmcIjSeDm+73eoqQpaXA7AZ22BL+6C+1mcUscgOsNd8WVlJuvlgAPsegcx7pjlV0Dg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "bin": {
         "rimraf": "bin.js"
@@ -35450,14 +35400,16 @@
     },
     "node_modules/metro/node_modules/throat": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
+      "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/metro/node_modules/wrap-ansi": {
       "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -35470,14 +35422,16 @@
     },
     "node_modules/metro/node_modules/y18n": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "dev": true,
-      "license": "ISC",
       "peer": true
     },
     "node_modules/metro/node_modules/yargs": {
       "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "cliui": "^6.0.0",
@@ -35498,8 +35452,9 @@
     },
     "node_modules/metro/node_modules/yargs-parser": {
       "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
       "dev": true,
-      "license": "ISC",
       "peer": true,
       "dependencies": {
         "camelcase": "^5.0.0",
@@ -36199,10 +36154,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/module-not-found-error": {
-      "version": "1.0.1",
-      "license": "MIT"
-    },
     "node_modules/moment": {
       "version": "2.29.3",
       "dev": true,
@@ -36457,12 +36408,13 @@
       "license": "0BSD"
     },
     "node_modules/nocache": {
-      "version": "2.1.0",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/nocache/-/nocache-3.0.4.tgz",
+      "integrity": "sha512-WDD0bdg9mbq6F4mRxEYcPWwfA1vxd0mrvKOyxI7Xj/atfRHVeutzuWByG//jfm4uPzp0y4Kj051EORCBSQMycw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">=4.0.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/node-addon-api": {
@@ -36677,8 +36629,9 @@
     },
     "node_modules/node-stream-zip": {
       "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.15.0.tgz",
+      "integrity": "sha512-LN4fydt9TqhZhThkZIVQnF9cwjU3qmUH9h78Mx/K7d3VvfRqqwthLwJEUOEL0QPZ0XQmNN7be5Ggit5+4dq3Bw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=0.12.0"
@@ -39233,8 +39186,9 @@
     },
     "node_modules/nullthrows": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
+      "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/num2fraction": {
@@ -39510,9 +39464,10 @@
       }
     },
     "node_modules/ob1": {
-      "version": "0.67.0",
+      "version": "0.70.3",
+      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.70.3.tgz",
+      "integrity": "sha512-Vy9GGhuXgDRY01QA6kdhToPd8AkLdLpX9GjH5kpqluVqTu70mgOm7tpGoJDZGaNbr9nJlJgnipqHJQRPORixIQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/object-assign": {
@@ -40916,8 +40871,9 @@
     },
     "node_modules/plist": {
       "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.5.tgz",
+      "integrity": "sha512-83vX4eYdQp3vP9SxuYgEM/G/pJQqLUz/V/xzPrzruLs7fz7jxGQ1msZ/mg1nwZxUSuOp4sb+/bEIbRrbzZRxDA==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "base64-js": "^1.5.1",
@@ -43197,15 +43153,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/proxyquire": {
-      "version": "2.1.3",
-      "license": "MIT",
-      "dependencies": {
-        "fill-keys": "^1.0.2",
-        "module-not-found-error": "^1.0.1",
-        "resolve": "^1.11.1"
-      }
-    },
     "node_modules/prr": {
       "version": "1.0.1",
       "dev": true,
@@ -43748,9 +43695,10 @@
       }
     },
     "node_modules/react-devtools-core": {
-      "version": "4.24.7",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.24.0.tgz",
+      "integrity": "sha512-Rw7FzYOOzcfyUPaAm9P3g0tFdGqGq2LLiAI+wjYcp6CsF3DeeMrRS3HZAho4s273C29G/DJhx0e8BpRE/QZNGg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "shell-quote": "^1.6.1",
@@ -43843,9 +43791,10 @@
       }
     },
     "node_modules/react-native-codegen": {
-      "version": "0.0.17",
+      "version": "0.69.1",
+      "resolved": "https://registry.npmjs.org/react-native-codegen/-/react-native-codegen-0.69.1.tgz",
+      "integrity": "sha512-TOZEqBarczcyYN3iZE3VpKkooOevaAzBq9n7lU0h9mQUvtRhLVyolc+a5K6cWI0e4v4K69I0MqzjPcPeFKo32Q==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/parser": "^7.14.0",
@@ -43855,9 +43804,10 @@
       }
     },
     "node_modules/react-native-gradle-plugin": {
-      "version": "0.0.6",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/react-native-gradle-plugin/-/react-native-gradle-plugin-0.0.7.tgz",
+      "integrity": "sha512-+4JpbIx42zGTONhBTIXSyfyHICHC29VTvhkkoUOJAh/XHPEixpuBduYgf6Y4y9wsN1ARlQhBBoptTvXvAFQf5g==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/react-redux": {
@@ -49541,8 +49491,9 @@
     },
     "node_modules/readline": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/readline/-/readline-1.3.0.tgz",
+      "integrity": "sha512-k2d6ACCkiNYz222Fs/iNze30rRJ1iIicW7JuX/7/cozvih6YCkFZH+J6mAFDVgv0dRBaAyr4jDqC95R2y4IADg==",
       "dev": true,
-      "license": "BSD",
       "peer": true
     },
     "node_modules/real-require": {
@@ -49554,8 +49505,9 @@
     },
     "node_modules/recast": {
       "version": "0.20.5",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.20.5.tgz",
+      "integrity": "sha512-E5qICoPoNL4yU0H0NoBDntNB0Q5oMSNh9usFctYniLBluTthi3RsQVBXIJNbApOlvSwW/RGxIuokPcAc59J5fQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "ast-types": "0.14.2",
@@ -49569,8 +49521,9 @@
     },
     "node_modules/recast/node_modules/tslib": {
       "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
       "dev": true,
-      "license": "0BSD",
       "peer": true
     },
     "node_modules/rechoir": {
@@ -51510,8 +51463,9 @@
     },
     "node_modules/serialize-error": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
+      "integrity": "sha512-ghgmKt5o4Tly5yEG/UJp8qTd0AN7Xalw4XBtDEKP655B699qMEtra1WlXeE6WIvdEG481JvRxULKsInq/iNysw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -54176,17 +54130,6 @@
         "url": "https://github.com/sponsors/steveukx/"
       }
     },
-    "node_modules/simple-plist": {
-      "version": "1.3.1",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "bplist-creator": "0.1.0",
-        "bplist-parser": "0.3.1",
-        "plist": "^3.0.5"
-      }
-    },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
       "dev": true,
@@ -54983,15 +54926,6 @@
         "safe-buffer": "~5.1.0"
       }
     },
-    "node_modules/stream-buffers": {
-      "version": "2.2.0",
-      "dev": true,
-      "license": "Unlicense",
-      "peer": true,
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
     "node_modules/stream-combiner2": {
       "version": "1.1.1",
       "dev": true,
@@ -55406,8 +55340,9 @@
     },
     "node_modules/sudo-prompt": {
       "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/sudo-prompt/-/sudo-prompt-9.2.1.tgz",
+      "integrity": "sha512-Mu7R0g4ig9TUuGSxJavny5Rv0egCEtpZRNMrZaYS1vxkiIxGiGUwoezU3LazIQ+KE04hTrTfNPgxU5gzi7F5Pw==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/superagent": {
@@ -57817,8 +57752,9 @@
     },
     "node_modules/temp": {
       "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.4.tgz",
+      "integrity": "sha512-s0ZZzd0BzYv5tLSptZooSjK8oj6C+c19p7Vqta9+6NPOf7r+fxq0cJe6/oN4LTC79sy5NY8ucOJNgwsKCSbfqg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "rimraf": "~2.6.2"
@@ -57837,8 +57773,9 @@
     },
     "node_modules/temp/node_modules/rimraf": {
       "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "dev": true,
-      "license": "ISC",
       "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
@@ -59697,8 +59634,10 @@
     },
     "node_modules/uglify-es": {
       "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
+      "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
+      "deprecated": "support for ECMAScript is superseded by `uglify-js` as of v3.13.0",
       "dev": true,
-      "license": "BSD-2-Clause",
       "peer": true,
       "dependencies": {
         "commander": "~2.13.0",
@@ -59713,8 +59652,9 @@
     },
     "node_modules/uglify-es/node_modules/commander": {
       "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+      "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/uglify-js": {
@@ -60483,16 +60423,14 @@
         }
       }
     },
-    "node_modules/use-subscription": {
-      "version": "1.5.1",
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
-      "dependencies": {
-        "object-assign": "^4.1.1"
-      },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/user-service": {
@@ -60674,8 +60612,9 @@
     },
     "node_modules/vlq": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vlq/-/vlq-1.0.1.tgz",
+      "integrity": "sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/vm-browserify": {
@@ -62044,28 +61983,6 @@
         }
       }
     },
-    "node_modules/xcode": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "simple-plist": "^1.1.0",
-        "uuid": "^7.0.3"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/xcode/node_modules/uuid": {
-      "version": "7.0.3",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/xdg-basedir": {
       "version": "4.0.0",
       "license": "MIT",
@@ -62111,21 +62028,6 @@
       "version": "2.2.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/xmldoc": {
-      "version": "1.1.3",
-      "dev": true,
-      "license": "https://raw.github.com/nfarina/xmldoc-js/master/LICENSE",
-      "peer": true,
-      "dependencies": {
-        "sax": "^1.2.4"
-      }
-    },
-    "node_modules/xmldoc/node_modules/sax": {
-      "version": "1.2.4",
-      "dev": true,
-      "license": "ISC",
-      "peer": true
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -62924,7 +62826,6 @@
       "dependencies": {
         "aws-signed-axios": "^1.1.0",
         "lambda-logger-middleware": "^1.0.3",
-        "proxyquire": "^2.1.3",
         "signed-objectid": "^1.0.1",
         "slic-tools": "*"
       },
@@ -68032,6 +67933,8 @@
       "dependencies": {
         "@jest/types": {
           "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -68043,60 +67946,38 @@
           }
         },
         "@react-native-community/cli": {
-          "version": "7.0.3",
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-8.0.2.tgz",
+          "integrity": "sha512-IwG3f6gKPlJucFH1Ex0SMD1P1rtOpdR9lloWoBZh3y0dbUbsNtiZZz0zJjZFm/2mtrIihplL7Yz3LmQBNm7xBQ==",
           "dev": true,
           "peer": true,
           "requires": {
-            "@react-native-community/cli-debugger-ui": "^7.0.3",
-            "@react-native-community/cli-hermes": "^6.3.0",
-            "@react-native-community/cli-plugin-metro": "^7.0.3",
-            "@react-native-community/cli-server-api": "^7.0.3",
-            "@react-native-community/cli-tools": "^6.2.0",
-            "@react-native-community/cli-types": "^6.0.0",
-            "appdirsjs": "^1.2.4",
+            "@react-native-community/cli-clean": "^8.0.0",
+            "@react-native-community/cli-config": "^8.0.2",
+            "@react-native-community/cli-debugger-ui": "^8.0.0",
+            "@react-native-community/cli-doctor": "^8.0.2",
+            "@react-native-community/cli-hermes": "^8.0.2",
+            "@react-native-community/cli-plugin-metro": "^8.0.0",
+            "@react-native-community/cli-server-api": "^8.0.0",
+            "@react-native-community/cli-tools": "^8.0.0",
+            "@react-native-community/cli-types": "^8.0.0",
             "chalk": "^4.1.2",
-            "command-exists": "^1.2.8",
             "commander": "^2.19.0",
-            "cosmiconfig": "^5.1.0",
-            "deepmerge": "^3.2.0",
-            "envinfo": "^7.7.2",
             "execa": "^1.0.0",
             "find-up": "^4.1.0",
             "fs-extra": "^8.1.0",
-            "glob": "^7.1.3",
             "graceful-fs": "^4.1.3",
-            "joi": "^17.2.1",
             "leven": "^3.1.0",
             "lodash": "^4.17.15",
             "minimist": "^1.2.0",
-            "node-stream-zip": "^1.9.1",
-            "ora": "^3.4.0",
-            "pretty-format": "^26.6.2",
             "prompts": "^2.4.0",
-            "semver": "^6.3.0",
-            "serve-static": "^1.13.1",
-            "strip-ansi": "^5.2.0",
-            "sudo-prompt": "^9.0.0",
-            "wcwidth": "^1.0.1"
-          }
-        },
-        "@react-native-community/cli-tools": {
-          "version": "6.2.0",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "appdirsjs": "^1.2.4",
-            "chalk": "^4.1.2",
-            "lodash": "^4.17.15",
-            "mime": "^2.4.1",
-            "node-fetch": "^2.6.0",
-            "open": "^6.2.0",
-            "semver": "^6.3.0",
-            "shell-quote": "1.6.1"
+            "semver": "^6.3.0"
           }
         },
         "@types/yargs": {
           "version": "15.0.14",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
+          "integrity": "sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -68105,22 +67986,18 @@
         },
         "ansi-styles": {
           "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "peer": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
         },
-        "argparse": {
-          "version": "1.0.10",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "sprintf-js": "~1.0.2"
-          }
-        },
         "chalk": {
           "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -68128,16 +68005,10 @@
             "supports-color": "^7.1.0"
           }
         },
-        "cli-cursor": {
-          "version": "2.1.0",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "restore-cursor": "^2.0.0"
-          }
-        },
         "color-convert": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -68146,27 +68017,22 @@
         },
         "color-name": {
           "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true,
           "peer": true
         },
         "commander": {
           "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
           "dev": true,
           "peer": true
         },
-        "cosmiconfig": {
-          "version": "5.2.1",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "import-fresh": "^2.0.0",
-            "is-directory": "^0.3.1",
-            "js-yaml": "^3.13.1",
-            "parse-json": "^4.0.0"
-          }
-        },
         "cross-spawn": {
           "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -68179,18 +68045,17 @@
           "dependencies": {
             "semver": {
               "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
               "dev": true,
               "peer": true
             }
           }
         },
-        "deepmerge": {
-          "version": "3.3.0",
-          "dev": true,
-          "peer": true
-        },
         "execa": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -68205,6 +68070,8 @@
         },
         "find-up": {
           "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -68214,6 +68081,8 @@
         },
         "fs-extra": {
           "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -68224,6 +68093,8 @@
         },
         "get-stream": {
           "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -68232,39 +68103,22 @@
         },
         "has-flag": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true,
           "peer": true
-        },
-        "import-fresh": {
-          "version": "2.0.0",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "caller-path": "^2.0.0",
-            "resolve-from": "^3.0.0"
-          }
         },
         "is-stream": {
           "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
           "dev": true,
           "peer": true
-        },
-        "is-wsl": {
-          "version": "1.1.0",
-          "dev": true,
-          "peer": true
-        },
-        "js-yaml": {
-          "version": "3.14.1",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
         },
         "jsonfile": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -68273,156 +68127,28 @@
         },
         "locate-path": {
           "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
           "dev": true,
           "peer": true,
           "requires": {
             "p-locate": "^4.1.0"
           }
         },
-        "log-symbols": {
-          "version": "2.2.0",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "chalk": "^2.0.1"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "3.2.1",
-              "dev": true,
-              "peer": true,
-              "requires": {
-                "color-convert": "^1.9.0"
-              }
-            },
-            "chalk": {
-              "version": "2.4.2",
-              "dev": true,
-              "peer": true,
-              "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-              }
-            },
-            "color-convert": {
-              "version": "1.9.3",
-              "dev": true,
-              "peer": true,
-              "requires": {
-                "color-name": "1.1.3"
-              }
-            },
-            "color-name": {
-              "version": "1.1.3",
-              "dev": true,
-              "peer": true
-            },
-            "has-flag": {
-              "version": "3.0.0",
-              "dev": true,
-              "peer": true
-            },
-            "supports-color": {
-              "version": "5.5.0",
-              "dev": true,
-              "peer": true,
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
-          }
-        },
-        "mimic-fn": {
-          "version": "1.2.0",
-          "dev": true,
-          "peer": true
-        },
         "npm-run-path": {
           "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
           "dev": true,
           "peer": true,
           "requires": {
             "path-key": "^2.0.0"
           }
         },
-        "onetime": {
-          "version": "2.0.1",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "mimic-fn": "^1.0.0"
-          }
-        },
-        "open": {
-          "version": "6.4.0",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "is-wsl": "^1.1.0"
-          }
-        },
-        "ora": {
-          "version": "3.4.0",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "chalk": "^2.4.2",
-            "cli-cursor": "^2.1.0",
-            "cli-spinners": "^2.0.0",
-            "log-symbols": "^2.2.0",
-            "strip-ansi": "^5.2.0",
-            "wcwidth": "^1.0.1"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "3.2.1",
-              "dev": true,
-              "peer": true,
-              "requires": {
-                "color-convert": "^1.9.0"
-              }
-            },
-            "chalk": {
-              "version": "2.4.2",
-              "dev": true,
-              "peer": true,
-              "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-              }
-            },
-            "color-convert": {
-              "version": "1.9.3",
-              "dev": true,
-              "peer": true,
-              "requires": {
-                "color-name": "1.1.3"
-              }
-            },
-            "color-name": {
-              "version": "1.1.3",
-              "dev": true,
-              "peer": true
-            },
-            "has-flag": {
-              "version": "3.0.0",
-              "dev": true,
-              "peer": true
-            },
-            "supports-color": {
-              "version": "5.5.0",
-              "dev": true,
-              "peer": true,
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
-          }
-        },
         "p-limit": {
           "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -68431,6 +68157,8 @@
         },
         "p-locate": {
           "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -68439,30 +68167,29 @@
         },
         "p-try": {
           "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
           "dev": true,
           "peer": true
         },
-        "parse-json": {
-          "version": "4.0.0",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
-          }
-        },
         "path-exists": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
           "dev": true,
           "peer": true
         },
         "path-key": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
           "dev": true,
           "peer": true
         },
         "pretty-format": {
           "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+          "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -68481,49 +68208,53 @@
           }
         },
         "react": {
-          "version": "17.0.2",
+          "version": "18.0.0",
+          "resolved": "https://registry.npmjs.org/react/-/react-18.0.0.tgz",
+          "integrity": "sha512-x+VL6wbT4JRVPm7EGxXhZ8w8LTROaxPXOqhlGyVSrv0sB1jkyFGgXxJ8LVoPRLvPR6/CIZGFmfzqUa2NYeMr2A==",
           "dev": true,
           "peer": true,
           "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1"
+            "loose-envify": "^1.1.0"
           }
         },
         "react-native": {
-          "version": "0.68.2",
+          "version": "0.69.1",
+          "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.69.1.tgz",
+          "integrity": "sha512-585NmzSuYUfday8YsfqgreFAZbXRI/kxKsiuaShwGHgkwdtmE5qA7WfGItgxZBOZD6g/Hm1YBUqSwIm07tPa6A==",
           "dev": true,
           "peer": true,
           "requires": {
             "@jest/create-cache-key-function": "^27.0.1",
-            "@react-native-community/cli": "^7.0.3",
-            "@react-native-community/cli-platform-android": "^7.0.1",
-            "@react-native-community/cli-platform-ios": "^7.0.1",
+            "@react-native-community/cli": "^8.0.0",
+            "@react-native-community/cli-platform-android": "^8.0.0",
+            "@react-native-community/cli-platform-ios": "^8.0.0",
             "@react-native/assets": "1.0.0",
             "@react-native/normalize-color": "2.0.0",
             "@react-native/polyfills": "2.0.0",
             "abort-controller": "^3.0.0",
             "anser": "^1.4.9",
             "base64-js": "^1.1.2",
-            "deprecated-react-native-prop-types": "^2.3.0",
             "event-target-shim": "^5.0.1",
             "hermes-engine": "~0.11.0",
             "invariant": "^2.2.4",
             "jsc-android": "^250230.2.1",
-            "metro-react-native-babel-transformer": "0.67.0",
-            "metro-runtime": "0.67.0",
-            "metro-source-map": "0.67.0",
+            "memoize-one": "^5.0.0",
+            "metro-react-native-babel-transformer": "0.70.3",
+            "metro-runtime": "0.70.3",
+            "metro-source-map": "0.70.3",
+            "mkdirp": "^0.5.1",
             "nullthrows": "^1.1.1",
             "pretty-format": "^26.5.2",
             "promise": "^8.0.3",
-            "react-devtools-core": "^4.23.0",
-            "react-native-codegen": "^0.0.17",
-            "react-native-gradle-plugin": "^0.0.6",
+            "react-devtools-core": "4.24.0",
+            "react-native-codegen": "^0.69.1",
+            "react-native-gradle-plugin": "^0.0.7",
             "react-refresh": "^0.4.0",
             "react-shallow-renderer": "16.14.1",
             "regenerator-runtime": "^0.13.2",
-            "scheduler": "^0.20.2",
+            "scheduler": "^0.21.0",
             "stacktrace-parser": "^0.1.3",
-            "use-subscription": ">=1.0.0 <1.6.0",
+            "use-sync-external-store": "^1.0.0",
             "whatwg-fetch": "^3.0.0",
             "ws": "^6.1.4"
           }
@@ -68540,31 +68271,20 @@
           "dev": true,
           "peer": true
         },
-        "resolve-from": {
-          "version": "3.0.0",
-          "dev": true,
-          "peer": true
-        },
-        "restore-cursor": {
-          "version": "2.0.0",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "onetime": "^2.0.0",
-            "signal-exit": "^3.0.2"
-          }
-        },
         "scheduler": {
-          "version": "0.20.2",
+          "version": "0.21.0",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.21.0.tgz",
+          "integrity": "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==",
           "dev": true,
           "peer": true,
           "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1"
+            "loose-envify": "^1.1.0"
           }
         },
         "shebang-command": {
           "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -68573,37 +68293,15 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
           "dev": true,
           "peer": true
         },
-        "shell-quote": {
-          "version": "1.6.1",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "array-filter": "~0.0.0",
-            "array-map": "~0.0.0",
-            "array-reduce": "~0.0.0",
-            "jsonify": "~0.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "4.1.1",
-              "dev": true,
-              "peer": true
-            }
-          }
-        },
         "supports-color": {
           "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -68612,6 +68310,8 @@
         },
         "universalify": {
           "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
           "dev": true,
           "peer": true
         },
@@ -68621,6 +68321,8 @@
         },
         "which": {
           "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -69399,7 +69101,9 @@
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.17.12"
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.18.6.tgz",
+      "integrity": "sha512-gvZnm1YAAxh13eJdkb9EWHBnF3eAub3XTLCZEehHT2kWxiKVRL64+ae5Y6Ivne0mVHmMYKT+xWgZO+gQhuLUBg=="
     },
     "@babel/helper-remap-async-to-generator": {
       "version": "7.16.8",
@@ -69528,12 +69232,14 @@
       }
     },
     "@babel/plugin-proposal-export-default-from": {
-      "version": "7.17.12",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-default-from/-/plugin-proposal-export-default-from-7.18.6.tgz",
+      "integrity": "sha512-oTvzWB16T9cB4j5kX8c8DuUHo/4QtR2P9vnUNKed9xqFP8Jos/IRniz1FiIryn6luDYoltDJSYF7RCpbm2doMg==",
       "dev": true,
       "peer": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.17.12",
-        "@babel/plugin-syntax-export-default-from": "^7.16.7"
+        "@babel/helper-plugin-utils": "^7.18.6",
+        "@babel/plugin-syntax-export-default-from": "^7.18.6"
       }
     },
     "@babel/plugin-proposal-export-namespace-from": {
@@ -69658,11 +69364,13 @@
       }
     },
     "@babel/plugin-syntax-export-default-from": {
-      "version": "7.16.7",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-default-from/-/plugin-syntax-export-default-from-7.18.6.tgz",
+      "integrity": "sha512-Kr//z3ujSVNx6E9z9ih5xXXMqK07VVTuqPmqGe6Mss/zW5XPeLZeSDZoP9ab/hT4wPKqAgjl2PnhPrcpk8Seew==",
       "dev": true,
       "peer": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.7"
+        "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
     "@babel/plugin-syntax-export-namespace-from": {
@@ -69909,14 +69617,6 @@
         "@babel/helper-plugin-utils": "^7.17.12"
       }
     },
-    "@babel/plugin-transform-object-assign": {
-      "version": "7.16.7",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.16.7"
-      }
-    },
     "@babel/plugin-transform-object-super": {
       "version": "7.16.7",
       "requires": {
@@ -69965,19 +69665,23 @@
       }
     },
     "@babel/plugin-transform-react-jsx-self": {
-      "version": "7.17.12",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.18.6.tgz",
+      "integrity": "sha512-A0LQGx4+4Jv7u/tWzoJF7alZwnBDQd6cGLh9P+Ttk4dpiL+J5p7NSNv/9tlEFFJDq3kjxOavWmbm6t0Gk+A3Ig==",
       "dev": true,
       "peer": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.17.12"
+        "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
     "@babel/plugin-transform-react-jsx-source": {
-      "version": "7.16.7",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.18.6.tgz",
+      "integrity": "sha512-utZmlASneDfdaMh0m/WausbjUjEdGrQJz0vFK93d7wD3xf5wBtX219+q6IlCNZeguIcxS2f/CvLZrlLSvSHQXw==",
       "dev": true,
       "peer": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.7"
+        "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
     "@babel/plugin-transform-react-pure-annotations": {
@@ -70182,7 +69886,9 @@
       }
     },
     "@babel/register": {
-      "version": "7.17.7",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.18.6.tgz",
+      "integrity": "sha512-tkYtONzaO8rQubZzpBnvZPFcHgh8D9F55IjOsYton4X2IBoyRn2ZSWQqySTZnUn2guZbxbQiAB27hJEbvXamhQ==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -70195,6 +69901,8 @@
       "dependencies": {
         "find-cache-dir": {
           "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+          "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -70205,6 +69913,8 @@
         },
         "find-up": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -70213,6 +69923,8 @@
         },
         "locate-path": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -70222,6 +69934,8 @@
         },
         "make-dir": {
           "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -70231,6 +69945,8 @@
         },
         "p-limit": {
           "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -70239,6 +69955,8 @@
         },
         "p-locate": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -70247,16 +69965,22 @@
         },
         "p-try": {
           "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
           "dev": true,
           "peer": true
         },
         "pify": {
           "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
           "dev": true,
           "peer": true
         },
         "pkg-dir": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+          "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -70265,6 +69989,8 @@
         },
         "semver": {
           "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true,
           "peer": true
         }
@@ -72838,60 +72564,23 @@
     "@polka/url": {
       "version": "1.0.0-next.21"
     },
-    "@react-native-community/cli-debugger-ui": {
-      "version": "7.0.3",
+    "@react-native-community/cli-clean": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-clean/-/cli-clean-8.0.0.tgz",
+      "integrity": "sha512-VY/kwyH5xp6oXiB9bcwa+I9W5k6WR/nX3s85FuMW76hSlgG1UVAGL04uZPwYlSmMZuSOSuoXOaIjJ7wAvQMBpg==",
       "dev": true,
       "peer": true,
       "requires": {
-        "serve-static": "^1.13.1"
-      }
-    },
-    "@react-native-community/cli-hermes": {
-      "version": "6.3.0",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@react-native-community/cli-platform-android": "^6.3.0",
-        "@react-native-community/cli-tools": "^6.2.0",
+        "@react-native-community/cli-tools": "^8.0.0",
         "chalk": "^4.1.2",
-        "hermes-profile-transformer": "^0.0.6",
-        "ip": "^1.1.5"
+        "execa": "^1.0.0",
+        "prompts": "^2.4.0"
       },
       "dependencies": {
-        "@react-native-community/cli-platform-android": {
-          "version": "6.3.0",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "@react-native-community/cli-tools": "^6.2.0",
-            "chalk": "^4.1.2",
-            "execa": "^1.0.0",
-            "fs-extra": "^8.1.0",
-            "glob": "^7.1.3",
-            "jetifier": "^1.6.2",
-            "lodash": "^4.17.15",
-            "logkitty": "^0.7.1",
-            "slash": "^3.0.0",
-            "xmldoc": "^1.1.2"
-          }
-        },
-        "@react-native-community/cli-tools": {
-          "version": "6.2.0",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "appdirsjs": "^1.2.4",
-            "chalk": "^4.1.2",
-            "lodash": "^4.17.15",
-            "mime": "^2.4.1",
-            "node-fetch": "^2.6.0",
-            "open": "^6.2.0",
-            "semver": "^6.3.0",
-            "shell-quote": "1.6.1"
-          }
-        },
         "ansi-styles": {
           "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -72900,6 +72589,8 @@
         },
         "chalk": {
           "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -72909,6 +72600,8 @@
         },
         "color-convert": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -72917,11 +72610,298 @@
         },
         "color-name": {
           "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true,
           "peer": true
         },
         "cross-spawn": {
           "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "execa": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true,
+          "peer": true
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+          "dev": true,
+          "peer": true
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "path-key": "^2.0.0"
+          }
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+          "dev": true,
+          "peer": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true,
+          "peer": true
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+          "dev": true,
+          "peer": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@react-native-community/cli-config": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-config/-/cli-config-8.0.2.tgz",
+      "integrity": "sha512-q0mL6QBzoLDHmlvkAKdgioIsMeyvvgRyu0WVLvT/v5DX6OVRvq4UEULLEY+7/P+760nPBQo4Ou1KqpP/SxmbXA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@react-native-community/cli-tools": "^8.0.0",
+        "cosmiconfig": "^5.1.0",
+        "deepmerge": "^3.2.0",
+        "glob": "^7.1.3",
+        "joi": "^17.2.1"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "cosmiconfig": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+          "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "import-fresh": "^2.0.0",
+            "is-directory": "^0.3.1",
+            "js-yaml": "^3.13.1",
+            "parse-json": "^4.0.0"
+          }
+        },
+        "deepmerge": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.3.0.tgz",
+          "integrity": "sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA==",
+          "dev": true,
+          "peer": true
+        },
+        "import-fresh": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+          "integrity": "sha512-eZ5H8rcgYazHbKC3PG4ClHNykCSxtAhxSSEM+2mb+7evD2CKF5V7c0dNum7AdpDh0ZdICwZY9sRSn8f+KH96sg==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "caller-path": "^2.0.0",
+            "resolve-from": "^3.0.0"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "resolve-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+          "integrity": "sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw==",
+          "dev": true,
+          "peer": true
+        }
+      }
+    },
+    "@react-native-community/cli-debugger-ui": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-8.0.0.tgz",
+      "integrity": "sha512-u2jq06GZwZ9sRERzd9FIgpW6yv4YOW4zz7Ym/B8eSzviLmy3yI/8mxJtvlGW+J8lBsfMcQoqJpqI6Rl1nZy9yQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "serve-static": "^1.13.1"
+      }
+    },
+    "@react-native-community/cli-doctor": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-doctor/-/cli-doctor-8.0.2.tgz",
+      "integrity": "sha512-XOimZcBR8n0Ipuk0iXfbZwxrt1r+2fZnskInZRf3SkYrLIKzDLF+ylKbNWJeuMWZSz9lQimo2cI/978bH1JQGw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@react-native-community/cli-config": "^8.0.2",
+        "@react-native-community/cli-platform-ios": "^8.0.2",
+        "@react-native-community/cli-tools": "^8.0.0",
+        "chalk": "^4.1.2",
+        "command-exists": "^1.2.8",
+        "envinfo": "^7.7.2",
+        "execa": "^1.0.0",
+        "hermes-profile-transformer": "^0.0.6",
+        "ip": "^1.1.5",
+        "node-stream-zip": "^1.9.1",
+        "ora": "^5.4.1",
+        "prompts": "^2.4.0",
+        "semver": "^6.3.0",
+        "strip-ansi": "^5.2.0",
+        "sudo-prompt": "^9.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+          "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+          "dev": true,
+          "peer": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true,
+          "peer": true
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -72934,6 +72914,8 @@
           "dependencies": {
             "semver": {
               "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
               "dev": true,
               "peer": true
             }
@@ -72941,6 +72923,8 @@
         },
         "execa": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -72953,18 +72937,10 @@
             "strip-eof": "^1.0.0"
           }
         },
-        "fs-extra": {
-          "version": "8.1.0",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
         "get-stream": {
           "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -72973,50 +72949,39 @@
         },
         "has-flag": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true,
           "peer": true
         },
         "is-stream": {
           "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
           "dev": true,
           "peer": true
-        },
-        "is-wsl": {
-          "version": "1.1.0",
-          "dev": true,
-          "peer": true
-        },
-        "jsonfile": {
-          "version": "4.0.0",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "graceful-fs": "^4.1.6"
-          }
         },
         "npm-run-path": {
           "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
           "dev": true,
           "peer": true,
           "requires": {
             "path-key": "^2.0.0"
           }
         },
-        "open": {
-          "version": "6.4.0",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "is-wsl": "^1.1.0"
-          }
-        },
         "path-key": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
           "dev": true,
           "peer": true
         },
         "shebang-command": {
           "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -73025,35 +72990,35 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
           "dev": true,
           "peer": true
         },
-        "shell-quote": {
-          "version": "1.6.1",
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "peer": true,
           "requires": {
-            "array-filter": "~0.0.0",
-            "array-map": "~0.0.0",
-            "array-reduce": "~0.0.0",
-            "jsonify": "~0.0.0"
+            "ansi-regex": "^4.1.0"
           }
         },
         "supports-color": {
           "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "peer": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
         },
-        "universalify": {
-          "version": "0.1.2",
-          "dev": true,
-          "peer": true
-        },
         "which": {
           "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -73062,25 +73027,24 @@
         }
       }
     },
-    "@react-native-community/cli-platform-android": {
-      "version": "7.0.1",
+    "@react-native-community/cli-hermes": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-8.0.2.tgz",
+      "integrity": "sha512-RZ9uHTf3UFtGTYxq88uENJEdaDB8ab+YPBDn+Li1u78IKwNeL04F0A1A3ab3hYUkG4PEPnL2rkYSlzzNFLOSPQ==",
       "dev": true,
       "peer": true,
       "requires": {
-        "@react-native-community/cli-tools": "^7.0.1",
+        "@react-native-community/cli-platform-android": "^8.0.2",
+        "@react-native-community/cli-tools": "^8.0.0",
         "chalk": "^4.1.2",
-        "execa": "^1.0.0",
-        "fs-extra": "^8.1.0",
-        "glob": "^7.1.3",
-        "jetifier": "^1.6.2",
-        "lodash": "^4.17.15",
-        "logkitty": "^0.7.1",
-        "slash": "^3.0.0",
-        "xmldoc": "^1.1.2"
+        "hermes-profile-transformer": "^0.0.6",
+        "ip": "^1.1.5"
       },
       "dependencies": {
         "ansi-styles": {
           "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -73089,6 +73053,8 @@
         },
         "chalk": {
           "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -73098,6 +73064,8 @@
         },
         "color-convert": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -73106,11 +73074,90 @@
         },
         "color-name": {
           "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true,
+          "peer": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true,
+          "peer": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@react-native-community/cli-platform-android": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-8.0.2.tgz",
+      "integrity": "sha512-pAEkt+GULesr8FphTpaNYSmu+O1CPQ2zCXkAg4kRd0WXpq3BsVqomyDWd/eMXTkY/yYQMGl6KilU2p9r/hnfhA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@react-native-community/cli-tools": "^8.0.0",
+        "chalk": "^4.1.2",
+        "execa": "^1.0.0",
+        "fs-extra": "^8.1.0",
+        "glob": "^7.1.3",
+        "jetifier": "^1.6.2",
+        "lodash": "^4.17.15",
+        "logkitty": "^0.7.1",
+        "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true,
           "peer": true
         },
         "cross-spawn": {
           "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -73123,6 +73170,8 @@
         },
         "execa": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -73137,6 +73186,8 @@
         },
         "fs-extra": {
           "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -73147,6 +73198,8 @@
         },
         "get-stream": {
           "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -73155,16 +73208,22 @@
         },
         "has-flag": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true,
           "peer": true
         },
         "is-stream": {
           "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
           "dev": true,
           "peer": true
         },
         "jsonfile": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -73173,6 +73232,8 @@
         },
         "npm-run-path": {
           "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -73181,16 +73242,22 @@
         },
         "path-key": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
           "dev": true,
           "peer": true
         },
         "semver": {
           "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true,
           "peer": true
         },
         "shebang-command": {
           "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -73199,11 +73266,15 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
           "dev": true,
           "peer": true
         },
         "supports-color": {
           "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -73212,11 +73283,15 @@
         },
         "universalify": {
           "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
           "dev": true,
           "peer": true
         },
         "which": {
           "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -73226,23 +73301,26 @@
       }
     },
     "@react-native-community/cli-platform-ios": {
-      "version": "7.0.1",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-8.0.2.tgz",
+      "integrity": "sha512-LxWzj6jIZr5Ot893TKFbt0/T3WkVe6pbc/FSTo+TDQq1FQr/Urv16Uqn0AcL4IX2O1g3Qd13d0vtR/Cdpn3VNw==",
       "dev": true,
       "peer": true,
       "requires": {
-        "@react-native-community/cli-tools": "^7.0.1",
+        "@react-native-community/cli-tools": "^8.0.0",
         "chalk": "^4.1.2",
         "execa": "^1.0.0",
         "glob": "^7.1.3",
         "js-yaml": "^3.13.1",
         "lodash": "^4.17.15",
         "ora": "^5.4.1",
-        "plist": "^3.0.2",
-        "xcode": "^3.0.0"
+        "plist": "^3.0.2"
       },
       "dependencies": {
         "ansi-styles": {
           "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -73251,6 +73329,8 @@
         },
         "argparse": {
           "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -73259,6 +73339,8 @@
         },
         "chalk": {
           "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -73268,6 +73350,8 @@
         },
         "color-convert": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -73276,11 +73360,15 @@
         },
         "color-name": {
           "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true,
           "peer": true
         },
         "cross-spawn": {
           "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -73293,6 +73381,8 @@
         },
         "execa": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -73307,6 +73397,8 @@
         },
         "get-stream": {
           "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -73315,16 +73407,22 @@
         },
         "has-flag": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true,
           "peer": true
         },
         "is-stream": {
           "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
           "dev": true,
           "peer": true
         },
         "js-yaml": {
           "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -73334,6 +73432,8 @@
         },
         "npm-run-path": {
           "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -73342,16 +73442,22 @@
         },
         "path-key": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
           "dev": true,
           "peer": true
         },
         "semver": {
           "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true,
           "peer": true
         },
         "shebang-command": {
           "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -73360,11 +73466,15 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
           "dev": true,
           "peer": true
         },
         "supports-color": {
           "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -73373,6 +73483,8 @@
         },
         "which": {
           "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -73382,39 +73494,28 @@
       }
     },
     "@react-native-community/cli-plugin-metro": {
-      "version": "7.0.3",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-8.0.0.tgz",
+      "integrity": "sha512-eIowV2ZRbzIWL3RIKVUUSahntXTuAeKzBSsFuhffLZphsV+UdKdtg5ATR9zbq7nsKap4ZseO5DkVqZngUkC7iQ==",
       "dev": true,
       "peer": true,
       "requires": {
-        "@react-native-community/cli-server-api": "^7.0.3",
-        "@react-native-community/cli-tools": "^6.2.0",
+        "@react-native-community/cli-server-api": "^8.0.0",
+        "@react-native-community/cli-tools": "^8.0.0",
         "chalk": "^4.1.2",
-        "metro": "^0.67.0",
-        "metro-config": "^0.67.0",
-        "metro-core": "^0.67.0",
-        "metro-react-native-babel-transformer": "^0.67.0",
-        "metro-resolver": "^0.67.0",
-        "metro-runtime": "^0.67.0",
+        "metro": "^0.70.1",
+        "metro-config": "^0.70.1",
+        "metro-core": "^0.70.1",
+        "metro-react-native-babel-transformer": "^0.70.1",
+        "metro-resolver": "^0.70.1",
+        "metro-runtime": "^0.70.1",
         "readline": "^1.3.0"
       },
       "dependencies": {
-        "@react-native-community/cli-tools": {
-          "version": "6.2.0",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "appdirsjs": "^1.2.4",
-            "chalk": "^4.1.2",
-            "lodash": "^4.17.15",
-            "mime": "^2.4.1",
-            "node-fetch": "^2.6.0",
-            "open": "^6.2.0",
-            "semver": "^6.3.0",
-            "shell-quote": "1.6.1"
-          }
-        },
         "ansi-styles": {
           "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -73423,6 +73524,8 @@
         },
         "chalk": {
           "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -73432,6 +73535,8 @@
         },
         "color-convert": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -73440,40 +73545,22 @@
         },
         "color-name": {
           "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true,
           "peer": true
         },
         "has-flag": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true,
           "peer": true
-        },
-        "is-wsl": {
-          "version": "1.1.0",
-          "dev": true,
-          "peer": true
-        },
-        "open": {
-          "version": "6.4.0",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "is-wsl": "^1.1.0"
-          }
-        },
-        "shell-quote": {
-          "version": "1.6.1",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "array-filter": "~0.0.0",
-            "array-map": "~0.0.0",
-            "array-reduce": "~0.0.0",
-            "jsonify": "~0.0.0"
-          }
         },
         "supports-color": {
           "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -73483,16 +73570,18 @@
       }
     },
     "@react-native-community/cli-server-api": {
-      "version": "7.0.3",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-8.0.0.tgz",
+      "integrity": "sha512-TxUs3sMl9clt7sdv30XETc6VRzyaEli2vDrk3TB5W5o5nSd1PmQdP4ccdGLO/nDRXwOy72QmmXlYWMg1XGU0Gg==",
       "dev": true,
       "peer": true,
       "requires": {
-        "@react-native-community/cli-debugger-ui": "^7.0.3",
-        "@react-native-community/cli-tools": "^6.2.0",
+        "@react-native-community/cli-debugger-ui": "^8.0.0",
+        "@react-native-community/cli-tools": "^8.0.0",
         "compression": "^1.7.1",
         "connect": "^3.6.5",
         "errorhandler": "^1.5.0",
-        "nocache": "^2.1.0",
+        "nocache": "^3.0.1",
         "pretty-format": "^26.6.2",
         "serve-static": "^1.13.1",
         "ws": "^7.5.1"
@@ -73500,6 +73589,8 @@
       "dependencies": {
         "@jest/types": {
           "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -73510,23 +73601,10 @@
             "chalk": "^4.0.0"
           }
         },
-        "@react-native-community/cli-tools": {
-          "version": "6.2.0",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "appdirsjs": "^1.2.4",
-            "chalk": "^4.1.2",
-            "lodash": "^4.17.15",
-            "mime": "^2.4.1",
-            "node-fetch": "^2.6.0",
-            "open": "^6.2.0",
-            "semver": "^6.3.0",
-            "shell-quote": "1.6.1"
-          }
-        },
         "@types/yargs": {
           "version": "15.0.14",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
+          "integrity": "sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -73535,6 +73613,8 @@
         },
         "ansi-styles": {
           "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -73543,6 +73623,8 @@
         },
         "chalk": {
           "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -73552,6 +73634,8 @@
         },
         "color-convert": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -73560,29 +73644,22 @@
         },
         "color-name": {
           "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true,
           "peer": true
         },
         "has-flag": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true,
           "peer": true
-        },
-        "is-wsl": {
-          "version": "1.1.0",
-          "dev": true,
-          "peer": true
-        },
-        "open": {
-          "version": "6.4.0",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "is-wsl": "^1.1.0"
-          }
         },
         "pretty-format": {
           "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+          "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -73592,19 +73669,10 @@
             "react-is": "^17.0.1"
           }
         },
-        "shell-quote": {
-          "version": "1.6.1",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "array-filter": "~0.0.0",
-            "array-map": "~0.0.0",
-            "array-reduce": "~0.0.0",
-            "jsonify": "~0.0.0"
-          }
-        },
         "supports-color": {
           "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -73614,7 +73682,9 @@
       }
     },
     "@react-native-community/cli-tools": {
-      "version": "7.0.1",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-8.0.0.tgz",
+      "integrity": "sha512-jA4y8CebrRZaOJFjc5zMOnls4KfHkBl2FUtBZV2vcWuedQHa6JVwo+KO88ta3Ysby3uY0+mrZagZfXk7c0mrBw==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -73631,6 +73701,8 @@
       "dependencies": {
         "ansi-styles": {
           "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -73639,6 +73711,8 @@
         },
         "chalk": {
           "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -73648,6 +73722,8 @@
         },
         "color-convert": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -73656,21 +73732,29 @@
         },
         "color-name": {
           "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true,
           "peer": true
         },
         "has-flag": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true,
           "peer": true
         },
         "is-wsl": {
           "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+          "integrity": "sha512-gfygJYZ2gLTDlmbWMI0CE2MwnFzSN/2SZfkMlItC4K/JBlsWVDB0bO6XhqcY13YXE7iMcAJnzTCJjPiTeJJ0Mw==",
           "dev": true,
           "peer": true
         },
         "open": {
           "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/open/-/open-6.4.0.tgz",
+          "integrity": "sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -73679,6 +73763,8 @@
         },
         "supports-color": {
           "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -73688,77 +73774,13 @@
       }
     },
     "@react-native-community/cli-types": {
-      "version": "6.0.0",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-types/-/cli-types-8.0.0.tgz",
+      "integrity": "sha512-1lZS1PEvMlFaN3Se1ksyoFWzMjk+YfKi490GgsqKJln9gvFm8tqVPdnXttI5Uf2DQf3BMse8Bk8dNH4oV6Ewow==",
       "dev": true,
       "peer": true,
       "requires": {
-        "ora": "^3.4.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.1",
-          "dev": true,
-          "peer": true
-        },
-        "cli-cursor": {
-          "version": "2.1.0",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "restore-cursor": "^2.0.0"
-          }
-        },
-        "log-symbols": {
-          "version": "2.2.0",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "chalk": "^2.0.1"
-          }
-        },
-        "mimic-fn": {
-          "version": "1.2.0",
-          "dev": true,
-          "peer": true
-        },
-        "onetime": {
-          "version": "2.0.1",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "mimic-fn": "^1.0.0"
-          }
-        },
-        "ora": {
-          "version": "3.4.0",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "chalk": "^2.4.2",
-            "cli-cursor": "^2.1.0",
-            "cli-spinners": "^2.0.0",
-            "log-symbols": "^2.2.0",
-            "strip-ansi": "^5.2.0",
-            "wcwidth": "^1.0.1"
-          }
-        },
-        "restore-cursor": {
-          "version": "2.0.0",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "onetime": "^2.0.0",
-            "signal-exit": "^3.0.2"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        }
+        "joi": "^17.2.1"
       }
     },
     "@react-native/assets": {
@@ -73768,6 +73790,8 @@
     },
     "@react-native/normalize-color": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-color/-/normalize-color-2.0.0.tgz",
+      "integrity": "sha512-Wip/xsc5lw8vsBlmY2MO/gFLp3MvuZ2baBZjDeTjjndMgM0h5sxz7AZR62RDPGgstp8Np7JzjvVqVT7tpFZqsw==",
       "dev": true,
       "peer": true
     },
@@ -75200,6 +75224,8 @@
     },
     "absolute-path": {
       "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/absolute-path/-/absolute-path-0.0.0.tgz",
+      "integrity": "sha512-HQiug4c+/s3WOvEnDRxXVmNtSG5s2gJM9r19BTcqjp7BWcE48PB+Y2G6jE65kqI0LpsQeMZygt/b60Gi4KxGyA==",
       "dev": true,
       "peer": true
     },
@@ -75412,6 +75438,8 @@
     },
     "ansi-fragments": {
       "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-fragments/-/ansi-fragments-0.2.1.tgz",
+      "integrity": "sha512-DykbNHxuXQwUDRv5ibc2b0x7uw7wmwOGLBUd5RmaQ5z8Lhx19vwvKV+FAsM5rEA6dEcHxX+/Ad5s9eF2k2bB+w==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -75422,21 +75450,29 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+          "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
           "dev": true,
           "peer": true
         },
         "colorette": {
           "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+          "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
           "dev": true,
           "peer": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
           "dev": true,
           "peer": true
         },
         "slice-ansi": {
           "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+          "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -75447,6 +75483,8 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -75484,6 +75522,8 @@
     },
     "appdirsjs": {
       "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/appdirsjs/-/appdirsjs-1.2.6.tgz",
+      "integrity": "sha512-D8wJNkqMCeQs3kLasatELsddox/Xqkhp+J07iXGyL54fVN7oc+nmNfYzGuCs1IEP6uBw+TfpuO3JKwc+lECy4w==",
       "dev": true,
       "peer": true
     },
@@ -75600,11 +75640,6 @@
       "version": "3.1.0",
       "dev": true
     },
-    "array-filter": {
-      "version": "0.0.1",
-      "dev": true,
-      "peer": true
-    },
     "array-find": {
       "version": "1.0.0",
       "dev": true
@@ -75626,16 +75661,6 @@
         "get-intrinsic": "^1.1.1",
         "is-string": "^1.0.7"
       }
-    },
-    "array-map": {
-      "version": "0.0.0",
-      "dev": true,
-      "peer": true
-    },
-    "array-reduce": {
-      "version": "0.0.0",
-      "dev": true,
-      "peer": true
     },
     "array-union": {
       "version": "2.1.0"
@@ -75752,6 +75777,8 @@
     },
     "ast-types": {
       "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.14.2.tgz",
+      "integrity": "sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -75760,6 +75787,8 @@
       "dependencies": {
         "tslib": {
           "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
           "dev": true,
           "peer": true
         }
@@ -75771,6 +75800,8 @@
     },
     "astral-regex": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true,
       "peer": true
     },
@@ -75999,6 +76030,8 @@
     },
     "babel-core": {
       "version": "7.0.0-bridge.0",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
+      "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
       "dev": true,
       "peer": true,
       "requires": {}
@@ -76198,6 +76231,8 @@
     },
     "babel-plugin-syntax-trailing-function-commas": {
       "version": "7.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz",
+      "integrity": "sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==",
       "dev": true,
       "peer": true
     },
@@ -76233,6 +76268,8 @@
     },
     "babel-preset-fbjs": {
       "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-fbjs/-/babel-preset-fbjs-3.4.0.tgz",
+      "integrity": "sha512-9ywCsCvo1ojrw0b+XYk7aFvTH6D9064t0RIL1rtMf3nsa02Xw41MS7sZw216Im35xj/UY0PDBQsa1brUDDF1Ow==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -76367,11 +76404,6 @@
         "hoopy": "^0.1.4",
         "tryer": "^1.0.1"
       }
-    },
-    "big-integer": {
-      "version": "1.6.51",
-      "dev": true,
-      "peer": true
     },
     "big.js": {
       "version": "5.2.2"
@@ -76554,22 +76586,6 @@
         }
       }
     },
-    "bplist-creator": {
-      "version": "0.1.0",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "stream-buffers": "2.2.x"
-      }
-    },
-    "bplist-parser": {
-      "version": "0.3.1",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "big-integer": "1.6.x"
-      }
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "requires": {
@@ -76663,12 +76679,14 @@
       }
     },
     "browserslist": {
-      "version": "4.21.0",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.1.tgz",
+      "integrity": "sha512-Nq8MFCSrnJXSc88yliwlzQe3qNe3VntIjhsArW9IJOEPSHNx23FalwApUVbzAWABLhYJJ7y8AynWI/XM8OdfjQ==",
       "requires": {
-        "caniuse-lite": "^1.0.30001358",
-        "electron-to-chromium": "^1.4.164",
+        "caniuse-lite": "^1.0.30001359",
+        "electron-to-chromium": "^1.4.172",
         "node-releases": "^2.0.5",
-        "update-browserslist-db": "^1.0.0"
+        "update-browserslist-db": "^1.0.4"
       }
     },
     "bs-logger": {
@@ -76947,7 +76965,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001358"
+      "version": "1.0.30001361",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001361.tgz",
+      "integrity": "sha512-ybhCrjNtkFji1/Wto6SSJKkWk6kZgVQsDq5QI83SafsF6FXv2JB4df9eEdH6g8sdGgqTXrFLjAxqBGgYoU3azQ=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -77682,6 +77702,8 @@
     },
     "command-exists": {
       "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
+      "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==",
       "dev": true,
       "peer": true
     },
@@ -78058,6 +78080,8 @@
     },
     "connect": {
       "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz",
+      "integrity": "sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -78069,6 +78093,8 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -78077,6 +78103,8 @@
         },
         "finalhandler": {
           "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+          "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -78091,11 +78119,15 @@
         },
         "ms": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
           "dev": true,
           "peer": true
         },
         "on-finished": {
           "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+          "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -78104,6 +78136,8 @@
         },
         "statuses": {
           "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+          "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
           "dev": true,
           "peer": true
         }
@@ -79211,21 +79245,13 @@
     },
     "denodeify": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz",
+      "integrity": "sha512-KNTihKNmQENUZeKu5fzfpzRqR5S2VMp4gl9RFHiWzj9DfvYQPMJ6XHKNaQxaGCXwPk6y9yme3aUoaiAe+KX+vg==",
       "dev": true,
       "peer": true
     },
     "depd": {
       "version": "2.0.0"
-    },
-    "deprecated-react-native-prop-types": {
-      "version": "2.3.0",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@react-native/normalize-color": "*",
-        "invariant": "*",
-        "prop-types": "*"
-      }
     },
     "deprecation": {
       "version": "2.3.1",
@@ -79607,7 +79633,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.4.164"
+      "version": "1.4.174",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.174.tgz",
+      "integrity": "sha512-JER+w+9MV2MBVFOXxP036bLlNOnzbYAWrWU8sNUwoOO69T3w4564WhM5H5atd8VVS8U4vpi0i0kdoYzm1NPQgQ=="
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -79742,6 +79770,8 @@
     },
     "envinfo": {
       "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.8.1.tgz",
+      "integrity": "sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==",
       "dev": true,
       "peer": true
     },
@@ -79771,6 +79801,8 @@
     },
     "errorhandler": {
       "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.5.1.tgz",
+      "integrity": "sha512-rcOwbfvP1WTViVoUjcfZicVzjhjTuhSMntHh6mW3IrEiyE6mJyXvsToJUJGlGlw/2xU9P5whlWNGlIDVeCiT4A==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -81002,13 +81034,6 @@
     "filesize": {
       "version": "8.0.7"
     },
-    "fill-keys": {
-      "version": "1.0.2",
-      "requires": {
-        "is-object": "~1.0.1",
-        "merge-descriptors": "~1.0.0"
-      }
-    },
     "fill-range": {
       "version": "7.0.1",
       "requires": {
@@ -81134,6 +81159,8 @@
     },
     "flow-parser": {
       "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.121.0.tgz",
+      "integrity": "sha512-1gIBiWJNR0tKUNv8gZuk7l9rVX06OuLzY9AoGio7y/JT4V1IZErEMEq2TJS+PFcw/y0RshZ1J/27VfK1UQzYVg==",
       "dev": true,
       "peer": true
     },
@@ -81969,20 +81996,26 @@
       "peer": true
     },
     "hermes-estree": {
-      "version": "0.5.0",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.6.0.tgz",
+      "integrity": "sha512-2YTGzJCkhdmT6VuNprWjXnvTvw/3iPNw804oc7yknvQpNKo+vJGZmtvLLCghOZf0OwzKaNAzeIMp71zQbNl09w==",
       "dev": true,
       "peer": true
     },
     "hermes-parser": {
-      "version": "0.5.0",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.6.0.tgz",
+      "integrity": "sha512-Vf58jBZca2+QBLR9h7B7mdg8oFz2g5ILz1iVouZ5DOrOrAfBmPfJjdjDT8jrO0f+iJ4/hSRrQHqHIjSnTaLUDQ==",
       "dev": true,
       "peer": true,
       "requires": {
-        "hermes-estree": "0.5.0"
+        "hermes-estree": "0.6.0"
       }
     },
     "hermes-profile-transformer": {
       "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/hermes-profile-transformer/-/hermes-profile-transformer-0.0.6.tgz",
+      "integrity": "sha512-cnN7bQUm65UWOy6cbGcCcZ3rpwW8Q/j4OP5aWRhEry4Z2t2aR1cjrbp0BS+KiBN0smvP1caBgAuxutvyvJILzQ==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -81991,6 +82024,8 @@
       "dependencies": {
         "source-map": {
           "version": "0.7.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+          "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
           "dev": true,
           "peer": true
         }
@@ -82819,9 +82854,6 @@
     },
     "is-obj": {
       "version": "1.0.1"
-    },
-    "is-object": {
-      "version": "1.0.2"
     },
     "is-path-cwd": {
       "version": "2.2.0"
@@ -84620,6 +84652,8 @@
     },
     "jest-serializer": {
       "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-27.5.1.tgz",
+      "integrity": "sha512-jZCyo6iIxO1aqUxpuBlwTDMkzOAJS4a3eYz3YzgxxVQFwLeSA7Jfq5cbqCY+JLvTDrWirgusI/0KwxKMgrdf7w==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -84878,6 +84912,8 @@
     },
     "jetifier": {
       "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/jetifier/-/jetifier-1.6.8.tgz",
+      "integrity": "sha512-3Zi16h6L5tXDRQJTb221cnRoVG9/9OvreLdLU2/ZjRv/GILL+2Cemt0IKvkowwkDpvouAU1DQPOJ7qaiHeIdrw==",
       "dev": true,
       "peer": true
     },
@@ -84922,6 +84958,8 @@
     },
     "jscodeshift": {
       "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.13.1.tgz",
+      "integrity": "sha512-lGyiEbGOvmMRKgWk4vf+lUrCWO/8YR8sUR3FKF1Cq5fovjZDlIcw3Hu5ppLHAnEXshVffvaM0eyuY/AbOeYpnQ==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -84948,6 +84986,8 @@
       "dependencies": {
         "ansi-styles": {
           "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -84956,6 +84996,8 @@
         },
         "braces": {
           "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -84973,6 +85015,8 @@
         },
         "chalk": {
           "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -84982,6 +85026,8 @@
         },
         "color-convert": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -84990,11 +85036,15 @@
         },
         "color-name": {
           "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true,
           "peer": true
         },
         "fill-range": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -85006,16 +85056,22 @@
         },
         "has-flag": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true,
           "peer": true
         },
         "is-buffer": {
           "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
           "dev": true,
           "peer": true
         },
         "is-extendable": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -85024,6 +85080,8 @@
         },
         "is-number": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -85032,6 +85090,8 @@
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
               "dev": true,
               "peer": true,
               "requires": {
@@ -85042,6 +85102,8 @@
         },
         "micromatch": {
           "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -85062,6 +85124,8 @@
           "dependencies": {
             "extend-shallow": {
               "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+              "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
               "dev": true,
               "peer": true,
               "requires": {
@@ -85073,6 +85137,8 @@
         },
         "supports-color": {
           "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -85081,6 +85147,8 @@
         },
         "to-regex-range": {
           "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -85090,6 +85158,8 @@
         },
         "write-file-atomic": {
           "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+          "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -85245,11 +85315,6 @@
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       }
-    },
-    "jsonify": {
-      "version": "0.0.0",
-      "dev": true,
-      "peer": true
     },
     "jsonparse": {
       "version": "1.3.1",
@@ -85451,6 +85516,8 @@
     },
     "klaw": {
       "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+      "integrity": "sha512-TED5xi9gGQjGpNnvRWknrwAB1eL5GciPfVFOt3Vk1OJCVDQbzuSfrF3hkUQKlsgKrG1F+0t5W0m+Fje1jIt8rw==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -85915,6 +85982,8 @@
     },
     "lodash.throttle": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
       "dev": true,
       "peer": true
     },
@@ -86176,6 +86245,8 @@
     },
     "logkitty": {
       "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/logkitty/-/logkitty-0.7.1.tgz",
+      "integrity": "sha512-/3ER20CTTbahrCrpYfPn7Xavv9diBROZpoXGVZDWMw4b/X4uuUwAC0ki85tgsdMRONURyIJbcOvS94QsUBYPbQ==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -86186,6 +86257,8 @@
       "dependencies": {
         "ansi-styles": {
           "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -86194,11 +86267,15 @@
         },
         "camelcase": {
           "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
           "dev": true,
           "peer": true
         },
         "cliui": {
           "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -86209,6 +86286,8 @@
         },
         "color-convert": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -86217,16 +86296,22 @@
         },
         "color-name": {
           "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true,
           "peer": true
         },
         "emoji-regex": {
           "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
           "dev": true,
           "peer": true
         },
         "find-up": {
           "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -86236,11 +86321,15 @@
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
           "dev": true,
           "peer": true
         },
         "locate-path": {
           "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -86249,6 +86338,8 @@
         },
         "p-limit": {
           "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -86257,6 +86348,8 @@
         },
         "p-locate": {
           "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -86265,16 +86358,22 @@
         },
         "p-try": {
           "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
           "dev": true,
           "peer": true
         },
         "path-exists": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
           "dev": true,
           "peer": true
         },
         "string-width": {
           "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -86285,6 +86384,8 @@
         },
         "wrap-ansi": {
           "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -86295,11 +86396,15 @@
         },
         "y18n": {
           "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
           "dev": true,
           "peer": true
         },
         "yargs": {
           "version": "15.4.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -86318,6 +86423,8 @@
         },
         "yargs-parser": {
           "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -86569,6 +86676,13 @@
         "fs-monkey": "^1.0.3"
       }
     },
+    "memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "dev": true,
+      "peer": true
+    },
     "memoizee": {
       "version": "0.4.15",
       "dev": true,
@@ -86681,7 +86795,9 @@
       "version": "1.1.2"
     },
     "metro": {
-      "version": "0.67.0",
+      "version": "0.70.3",
+      "resolved": "https://registry.npmjs.org/metro/-/metro-0.70.3.tgz",
+      "integrity": "sha512-uEWS7xg8oTetQDABYNtsyeUjdLhH3KAvLFpaFFoJqUpOk2A3iygszdqmjobFl6W4zrvKDJS+XxdMR1roYvUhTw==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -86694,7 +86810,7 @@
         "@babel/types": "^7.0.0",
         "absolute-path": "^0.0.0",
         "accepts": "^1.3.7",
-        "async": "^2.4.0",
+        "async": "^3.2.2",
         "chalk": "^4.0.0",
         "ci-info": "^2.0.0",
         "connect": "^3.6.5",
@@ -86702,30 +86818,29 @@
         "denodeify": "^1.2.1",
         "error-stack-parser": "^2.0.6",
         "fs-extra": "^1.0.0",
-        "graceful-fs": "^4.1.3",
-        "hermes-parser": "0.5.0",
+        "graceful-fs": "^4.2.4",
+        "hermes-parser": "0.6.0",
         "image-size": "^0.6.0",
         "invariant": "^2.2.4",
         "jest-haste-map": "^27.3.1",
-        "jest-worker": "^26.0.0",
+        "jest-worker": "^27.2.0",
         "lodash.throttle": "^4.1.1",
-        "metro-babel-transformer": "0.67.0",
-        "metro-cache": "0.67.0",
-        "metro-cache-key": "0.67.0",
-        "metro-config": "0.67.0",
-        "metro-core": "0.67.0",
-        "metro-hermes-compiler": "0.67.0",
-        "metro-inspector-proxy": "0.67.0",
-        "metro-minify-uglify": "0.67.0",
-        "metro-react-native-babel-preset": "0.67.0",
-        "metro-resolver": "0.67.0",
-        "metro-runtime": "0.67.0",
-        "metro-source-map": "0.67.0",
-        "metro-symbolicate": "0.67.0",
-        "metro-transform-plugins": "0.67.0",
-        "metro-transform-worker": "0.67.0",
+        "metro-babel-transformer": "0.70.3",
+        "metro-cache": "0.70.3",
+        "metro-cache-key": "0.70.3",
+        "metro-config": "0.70.3",
+        "metro-core": "0.70.3",
+        "metro-hermes-compiler": "0.70.3",
+        "metro-inspector-proxy": "0.70.3",
+        "metro-minify-uglify": "0.70.3",
+        "metro-react-native-babel-preset": "0.70.3",
+        "metro-resolver": "0.70.3",
+        "metro-runtime": "0.70.3",
+        "metro-source-map": "0.70.3",
+        "metro-symbolicate": "0.70.3",
+        "metro-transform-plugins": "0.70.3",
+        "metro-transform-worker": "0.70.3",
         "mime-types": "^2.1.27",
-        "mkdirp": "^0.5.1",
         "node-fetch": "^2.2.0",
         "nullthrows": "^1.1.1",
         "rimraf": "^2.5.4",
@@ -86740,6 +86855,8 @@
       "dependencies": {
         "@jest/types": {
           "version": "27.5.1",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.5.1.tgz",
+          "integrity": "sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -86752,6 +86869,8 @@
         },
         "@types/yargs": {
           "version": "16.0.4",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+          "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -86760,27 +86879,25 @@
         },
         "ansi-styles": {
           "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "peer": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
         },
-        "async": {
-          "version": "2.6.4",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "lodash": "^4.17.14"
-          }
-        },
         "camelcase": {
           "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
           "dev": true,
           "peer": true
         },
         "chalk": {
           "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -86790,11 +86907,15 @@
         },
         "ci-info": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+          "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
           "dev": true,
           "peer": true
         },
         "cliui": {
           "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -86805,6 +86926,8 @@
         },
         "color-convert": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -86813,11 +86936,15 @@
         },
         "color-name": {
           "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true,
           "peer": true
         },
         "debug": {
           "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -86826,11 +86953,15 @@
         },
         "emoji-regex": {
           "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
           "dev": true,
           "peer": true
         },
         "find-up": {
           "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -86840,6 +86971,8 @@
         },
         "fs-extra": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+          "integrity": "sha512-VerQV6vEKuhDWD2HGOybV6v5I73syoc/cXAbKlgTC7M/oFVEtklWlp9QH2Ijw3IaWDOQcMkldSPa7zXy79Z/UQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -86850,21 +86983,29 @@
         },
         "has-flag": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true,
           "peer": true
         },
         "image-size": {
           "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.6.3.tgz",
+          "integrity": "sha512-47xSUiQioGaB96nqtp5/q55m0aBQSQdyIloMOc/x+QVTDZLNmXE892IIDrJ0hM1A5vcNUDD5tDffkSP5lCaIIA==",
           "dev": true,
           "peer": true
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
           "dev": true,
           "peer": true
         },
         "jest-haste-map": {
           "version": "27.5.1",
+          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-27.5.1.tgz",
+          "integrity": "sha512-7GgkZ4Fw4NFbMSDSpZwXeBiIbx+t/46nJ2QitkOjvwPYyZmqttu2TDSimMHP1EkPOi4xUZAN1doE5Vd25H4Jng==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -86881,35 +87022,19 @@
             "jest-worker": "^27.5.1",
             "micromatch": "^4.0.4",
             "walker": "^1.0.7"
-          },
-          "dependencies": {
-            "jest-worker": {
-              "version": "27.5.1",
-              "dev": true,
-              "peer": true,
-              "requires": {
-                "@types/node": "*",
-                "merge-stream": "^2.0.0",
-                "supports-color": "^8.0.0"
-              }
-            },
-            "supports-color": {
-              "version": "8.1.1",
-              "dev": true,
-              "peer": true,
-              "requires": {
-                "has-flag": "^4.0.0"
-              }
-            }
           }
         },
         "jest-regex-util": {
           "version": "27.5.1",
+          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-27.5.1.tgz",
+          "integrity": "sha512-4bfKq2zie+x16okqDXjXn9ql2B0dScQu+vcwe4TvFVhkVyuWLqpZrZtXxLLWoXYgn0E87I6r6GRYHF7wFZBUvg==",
           "dev": true,
           "peer": true
         },
         "jest-util": {
           "version": "27.5.1",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.5.1.tgz",
+          "integrity": "sha512-Kv2o/8jNvX1MQ0KGtw480E/w4fBCDOnH6+6DmeKi6LZUIlKA5kwY0YNdlzaWTiVgxqAqik11QyxDOKk543aKXw==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -86923,23 +87048,17 @@
           "dependencies": {
             "ci-info": {
               "version": "3.3.2",
+              "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.2.tgz",
+              "integrity": "sha512-xmDt/QIAdeZ9+nfdPsaBCpMvHNLFiLdjj59qjqn+6iPe6YmHGQ35sBnQ8uslRBXFmXkiZQOJRjvQeoGppoTjjg==",
               "dev": true,
               "peer": true
             }
           }
         },
-        "jest-worker": {
-          "version": "26.6.2",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "@types/node": "*",
-            "merge-stream": "^2.0.0",
-            "supports-color": "^7.0.0"
-          }
-        },
         "jsonfile": {
           "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+          "integrity": "sha512-PKllAqbgLgxHaj8TElYymKCAgrASebJrWpTnEkOaTowt23VKXXN0sUeriJ+eh7y6ufb/CC5ap11pz71/cM0hUw==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -86948,6 +87067,8 @@
         },
         "locate-path": {
           "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -86956,11 +87077,15 @@
         },
         "ms": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
           "dev": true,
           "peer": true
         },
         "p-limit": {
           "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -86969,6 +87094,8 @@
         },
         "p-locate": {
           "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -86977,16 +87104,22 @@
         },
         "p-try": {
           "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
           "dev": true,
           "peer": true
         },
         "path-exists": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
           "dev": true,
           "peer": true
         },
         "rimraf": {
           "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -86995,11 +87128,15 @@
         },
         "source-map": {
           "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
           "dev": true,
           "peer": true
         },
         "string-width": {
           "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -87010,6 +87147,8 @@
         },
         "supports-color": {
           "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -87018,6 +87157,8 @@
         },
         "temp": {
           "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
+          "integrity": "sha512-jtnWJs6B1cZlHs9wPG7BrowKxZw/rf6+UpGAkr8AaYmiTyTO7zQlLoST8zx/8TcUPnZmeBoB+H8ARuHZaSijVw==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -87027,6 +87168,8 @@
           "dependencies": {
             "rimraf": {
               "version": "2.2.8",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+              "integrity": "sha512-R5KMKHnPAQaZMqLOsyuyUmcIjSeDm+73eoqQpaXA7AZ22BL+6C+1mcUscgOsNd8WVlJuvlgAPsegcx7pjlV0Dg==",
               "dev": true,
               "peer": true
             }
@@ -87034,11 +87177,15 @@
         },
         "throat": {
           "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
+          "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
           "dev": true,
           "peer": true
         },
         "wrap-ansi": {
           "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -87049,11 +87196,15 @@
         },
         "y18n": {
           "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
           "dev": true,
           "peer": true
         },
         "yargs": {
           "version": "15.4.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -87072,6 +87223,8 @@
         },
         "yargs-parser": {
           "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -87082,28 +87235,33 @@
       }
     },
     "metro-babel-transformer": {
-      "version": "0.67.0",
+      "version": "0.70.3",
+      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.70.3.tgz",
+      "integrity": "sha512-bWhZRMn+mIOR/s3BDpFevWScz9sV8FGktVfMlF1eJBLoX24itHDbXvTktKBYi38PWIKcHedh6THSFpJogfuwNA==",
       "dev": true,
       "peer": true,
       "requires": {
         "@babel/core": "^7.14.0",
-        "hermes-parser": "0.5.0",
-        "metro-source-map": "0.67.0",
+        "hermes-parser": "0.6.0",
+        "metro-source-map": "0.70.3",
         "nullthrows": "^1.1.1"
       }
     },
     "metro-cache": {
-      "version": "0.67.0",
+      "version": "0.70.3",
+      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.70.3.tgz",
+      "integrity": "sha512-iCix/+z812fUqa6KlOxaTkY6LQQDoXIe/VljXkGIvpygSCmYyhjQpfQVZEVVPezFmUBYXNdabdQ6cYx6JX3yMg==",
       "dev": true,
       "peer": true,
       "requires": {
-        "metro-core": "0.67.0",
-        "mkdirp": "^0.5.1",
+        "metro-core": "0.70.3",
         "rimraf": "^2.5.4"
       },
       "dependencies": {
         "rimraf": {
           "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -87113,25 +87271,31 @@
       }
     },
     "metro-cache-key": {
-      "version": "0.67.0",
+      "version": "0.70.3",
+      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.70.3.tgz",
+      "integrity": "sha512-0zpw+IcpM3hmGd5sKMdxNv3sbOIUYnMUvx1/yaM6vNRReSPmOLX0bP8fYf3CGgk8NEreZ1OHbVsuw7bdKt40Mw==",
       "dev": true,
       "peer": true
     },
     "metro-config": {
-      "version": "0.67.0",
+      "version": "0.70.3",
+      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.70.3.tgz",
+      "integrity": "sha512-SSCDjSTygoCgzoj61DdrBeJzZDRwQxUEfcgc6t6coxWSExXNR4mOngz0q4SAam49Bmjq9J2Jft6qUKnUTPrRgA==",
       "dev": true,
       "peer": true,
       "requires": {
         "cosmiconfig": "^5.0.5",
         "jest-validate": "^26.5.2",
-        "metro": "0.67.0",
-        "metro-cache": "0.67.0",
-        "metro-core": "0.67.0",
-        "metro-runtime": "0.67.0"
+        "metro": "0.70.3",
+        "metro-cache": "0.70.3",
+        "metro-core": "0.70.3",
+        "metro-runtime": "0.70.3"
       },
       "dependencies": {
         "@jest/types": {
           "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -87144,6 +87308,8 @@
         },
         "@types/yargs": {
           "version": "15.0.14",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
+          "integrity": "sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -87152,6 +87318,8 @@
         },
         "ansi-styles": {
           "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -87160,6 +87328,8 @@
         },
         "argparse": {
           "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -87168,6 +87338,8 @@
         },
         "chalk": {
           "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -87177,6 +87349,8 @@
         },
         "color-convert": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -87185,11 +87359,15 @@
         },
         "color-name": {
           "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true,
           "peer": true
         },
         "cosmiconfig": {
           "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+          "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -87201,11 +87379,15 @@
         },
         "has-flag": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true,
           "peer": true
         },
         "import-fresh": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+          "integrity": "sha512-eZ5H8rcgYazHbKC3PG4ClHNykCSxtAhxSSEM+2mb+7evD2CKF5V7c0dNum7AdpDh0ZdICwZY9sRSn8f+KH96sg==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -87215,11 +87397,15 @@
         },
         "jest-get-type": {
           "version": "26.3.0",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+          "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
           "dev": true,
           "peer": true
         },
         "jest-validate": {
           "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.6.2.tgz",
+          "integrity": "sha512-NEYZ9Aeyj0i5rQqbq+tpIOom0YS1u2MVu6+euBsvpgIme+FOfRmoC4R5p0JiAUpaFvFy24xgrpMknarR/93XjQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -87233,6 +87419,8 @@
         },
         "js-yaml": {
           "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -87242,6 +87430,8 @@
         },
         "parse-json": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -87251,6 +87441,8 @@
         },
         "pretty-format": {
           "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+          "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -87262,11 +87454,15 @@
         },
         "resolve-from": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+          "integrity": "sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw==",
           "dev": true,
           "peer": true
         },
         "supports-color": {
           "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -87276,17 +87472,21 @@
       }
     },
     "metro-core": {
-      "version": "0.67.0",
+      "version": "0.70.3",
+      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.70.3.tgz",
+      "integrity": "sha512-NzfHB/w5R7yLaOeU1tzPTbBzCRsYSvpKJkLMP0yudszKZzIAZqNdjoEJ9GZ688Wi0ynZxcU0BxukXh4my80ZBw==",
       "dev": true,
       "peer": true,
       "requires": {
         "jest-haste-map": "^27.3.1",
         "lodash.throttle": "^4.1.1",
-        "metro-resolver": "0.67.0"
+        "metro-resolver": "0.70.3"
       },
       "dependencies": {
         "@jest/types": {
           "version": "27.5.1",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.5.1.tgz",
+          "integrity": "sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -87299,6 +87499,8 @@
         },
         "@types/yargs": {
           "version": "16.0.4",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+          "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -87307,6 +87509,8 @@
         },
         "ansi-styles": {
           "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -87315,6 +87519,8 @@
         },
         "chalk": {
           "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -87324,6 +87530,8 @@
         },
         "color-convert": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -87332,16 +87540,22 @@
         },
         "color-name": {
           "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true,
           "peer": true
         },
         "has-flag": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true,
           "peer": true
         },
         "jest-haste-map": {
           "version": "27.5.1",
+          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-27.5.1.tgz",
+          "integrity": "sha512-7GgkZ4Fw4NFbMSDSpZwXeBiIbx+t/46nJ2QitkOjvwPYyZmqttu2TDSimMHP1EkPOi4xUZAN1doE5Vd25H4Jng==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -87362,11 +87576,15 @@
         },
         "jest-regex-util": {
           "version": "27.5.1",
+          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-27.5.1.tgz",
+          "integrity": "sha512-4bfKq2zie+x16okqDXjXn9ql2B0dScQu+vcwe4TvFVhkVyuWLqpZrZtXxLLWoXYgn0E87I6r6GRYHF7wFZBUvg==",
           "dev": true,
           "peer": true
         },
         "jest-util": {
           "version": "27.5.1",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.5.1.tgz",
+          "integrity": "sha512-Kv2o/8jNvX1MQ0KGtw480E/w4fBCDOnH6+6DmeKi6LZUIlKA5kwY0YNdlzaWTiVgxqAqik11QyxDOKk543aKXw==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -87380,6 +87598,8 @@
         },
         "supports-color": {
           "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -87389,12 +87609,16 @@
       }
     },
     "metro-hermes-compiler": {
-      "version": "0.67.0",
+      "version": "0.70.3",
+      "resolved": "https://registry.npmjs.org/metro-hermes-compiler/-/metro-hermes-compiler-0.70.3.tgz",
+      "integrity": "sha512-W6WttLi4E72JL/NyteQ84uxYOFMibe0PUr9aBKuJxxfCq6QRnJKOVcNY0NLW0He2tneXGk+8ZsNz8c0flEvYqg==",
       "dev": true,
       "peer": true
     },
     "metro-inspector-proxy": {
-      "version": "0.67.0",
+      "version": "0.70.3",
+      "resolved": "https://registry.npmjs.org/metro-inspector-proxy/-/metro-inspector-proxy-0.70.3.tgz",
+      "integrity": "sha512-qQoNdPGrmyoJSWYkxSDpTaAI8xyqVdNDVVj9KRm1PG8niSuYmrCCFGLLFsMvkVYwsCWUGHoGBx0UoAzVp14ejw==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -87406,6 +87630,8 @@
       "dependencies": {
         "ansi-styles": {
           "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -87414,11 +87640,15 @@
         },
         "camelcase": {
           "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
           "dev": true,
           "peer": true
         },
         "cliui": {
           "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -87429,6 +87659,8 @@
         },
         "color-convert": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -87437,11 +87669,15 @@
         },
         "color-name": {
           "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true,
           "peer": true
         },
         "debug": {
           "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -87450,11 +87686,15 @@
         },
         "emoji-regex": {
           "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
           "dev": true,
           "peer": true
         },
         "find-up": {
           "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -87464,11 +87704,15 @@
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
           "dev": true,
           "peer": true
         },
         "locate-path": {
           "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -87477,11 +87721,15 @@
         },
         "ms": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
           "dev": true,
           "peer": true
         },
         "p-limit": {
           "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -87490,6 +87738,8 @@
         },
         "p-locate": {
           "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -87498,16 +87748,22 @@
         },
         "p-try": {
           "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
           "dev": true,
           "peer": true
         },
         "path-exists": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
           "dev": true,
           "peer": true
         },
         "string-width": {
           "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -87518,6 +87774,8 @@
         },
         "wrap-ansi": {
           "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -87528,11 +87786,15 @@
         },
         "y18n": {
           "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
           "dev": true,
           "peer": true
         },
         "yargs": {
           "version": "15.4.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -87551,6 +87813,8 @@
         },
         "yargs-parser": {
           "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -87561,7 +87825,9 @@
       }
     },
     "metro-minify-uglify": {
-      "version": "0.67.0",
+      "version": "0.70.3",
+      "resolved": "https://registry.npmjs.org/metro-minify-uglify/-/metro-minify-uglify-0.70.3.tgz",
+      "integrity": "sha512-oHyjV9WDqOlDE1FPtvs6tIjjeY/oP1PNUPYL1wqyYtqvjN+zzAOrcbsAAL1sv+WARaeiMsWkF2bwtNo+Hghoog==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -87569,11 +87835,14 @@
       }
     },
     "metro-react-native-babel-preset": {
-      "version": "0.67.0",
+      "version": "0.70.3",
+      "resolved": "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.70.3.tgz",
+      "integrity": "sha512-4Nxc1zEiHEu+GTdEMEsHnRgfaBkg8f/Td3+FcQ8NTSvs+xL3LBrQy6N07idWSQZHIdGFf+tTHvRfSIWLD8u8Tg==",
       "dev": true,
       "peer": true,
       "requires": {
         "@babel/core": "^7.14.0",
+        "@babel/plugin-proposal-async-generator-functions": "^7.0.0",
         "@babel/plugin-proposal-class-properties": "^7.0.0",
         "@babel/plugin-proposal-export-default-from": "^7.0.0",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
@@ -87593,17 +87862,15 @@
         "@babel/plugin-transform-destructuring": "^7.0.0",
         "@babel/plugin-transform-exponentiation-operator": "^7.0.0",
         "@babel/plugin-transform-flow-strip-types": "^7.0.0",
-        "@babel/plugin-transform-for-of": "^7.0.0",
         "@babel/plugin-transform-function-name": "^7.0.0",
         "@babel/plugin-transform-literals": "^7.0.0",
         "@babel/plugin-transform-modules-commonjs": "^7.0.0",
-        "@babel/plugin-transform-object-assign": "^7.0.0",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.0.0",
         "@babel/plugin-transform-parameters": "^7.0.0",
         "@babel/plugin-transform-react-display-name": "^7.0.0",
         "@babel/plugin-transform-react-jsx": "^7.0.0",
         "@babel/plugin-transform-react-jsx-self": "^7.0.0",
         "@babel/plugin-transform-react-jsx-source": "^7.0.0",
-        "@babel/plugin-transform-regenerator": "^7.0.0",
         "@babel/plugin-transform-runtime": "^7.0.0",
         "@babel/plugin-transform-shorthand-properties": "^7.0.0",
         "@babel/plugin-transform-spread": "^7.0.0",
@@ -87617,27 +87884,33 @@
       "dependencies": {
         "react-refresh": {
           "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.4.3.tgz",
+          "integrity": "sha512-Hwln1VNuGl/6bVwnd0Xdn1e84gT/8T9aYNL+HAKDArLCS7LWjwr7StE30IEYbIkx0Vi3vs+coQxe+SQDbGbbpA==",
           "dev": true,
           "peer": true
         }
       }
     },
     "metro-react-native-babel-transformer": {
-      "version": "0.67.0",
+      "version": "0.70.3",
+      "resolved": "https://registry.npmjs.org/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.70.3.tgz",
+      "integrity": "sha512-WKBU6S/G50j9cfmFM4k4oRYprd8u3qjleD4so1E2zbTNILg+gYla7ZFGCAvi2G0ZcqS2XuGCR375c2hF6VVvwg==",
       "dev": true,
       "peer": true,
       "requires": {
         "@babel/core": "^7.14.0",
         "babel-preset-fbjs": "^3.4.0",
-        "hermes-parser": "0.5.0",
-        "metro-babel-transformer": "0.67.0",
-        "metro-react-native-babel-preset": "0.67.0",
-        "metro-source-map": "0.67.0",
+        "hermes-parser": "0.6.0",
+        "metro-babel-transformer": "0.70.3",
+        "metro-react-native-babel-preset": "0.70.3",
+        "metro-source-map": "0.70.3",
         "nullthrows": "^1.1.1"
       }
     },
     "metro-resolver": {
-      "version": "0.67.0",
+      "version": "0.70.3",
+      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.70.3.tgz",
+      "integrity": "sha512-5Pc5S/Gs4RlLbziuIWtvtFd9GRoILlaRC8RZDVq5JZWcWHywKy/PjNmOBNhpyvtRlzpJfy/ssIfLhu8zINt1Mw==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -87645,39 +87918,50 @@
       }
     },
     "metro-runtime": {
-      "version": "0.67.0",
+      "version": "0.70.3",
+      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.70.3.tgz",
+      "integrity": "sha512-22xU7UdXZacniTIDZgN2EYtmfau2pPyh97Dcs+cWrLcJYgfMKjWBtesnDcUAQy3PHekDYvBdJZkoQUeskYTM+w==",
       "dev": true,
-      "peer": true
+      "peer": true,
+      "requires": {
+        "@babel/runtime": "^7.0.0"
+      }
     },
     "metro-source-map": {
-      "version": "0.67.0",
+      "version": "0.70.3",
+      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.70.3.tgz",
+      "integrity": "sha512-zsYtZGrwRbbGEFHtmMqqeCH9K9aTGNVPsurMOWCUeQA3VGyVGXPGtLMC+CdAM9jLpUyg6jw2xh0esxi+tYH7Uw==",
       "dev": true,
       "peer": true,
       "requires": {
         "@babel/traverse": "^7.14.0",
         "@babel/types": "^7.0.0",
         "invariant": "^2.2.4",
-        "metro-symbolicate": "0.67.0",
+        "metro-symbolicate": "0.70.3",
         "nullthrows": "^1.1.1",
-        "ob1": "0.67.0",
+        "ob1": "0.70.3",
         "source-map": "^0.5.6",
         "vlq": "^1.0.0"
       },
       "dependencies": {
         "source-map": {
           "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
           "dev": true,
           "peer": true
         }
       }
     },
     "metro-symbolicate": {
-      "version": "0.67.0",
+      "version": "0.70.3",
+      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.70.3.tgz",
+      "integrity": "sha512-JTYkF1dpeDUssQ84juE1ycnhHki2ylJBBdJE1JHtfu5oC+z1ElDbBdPHq90Uvt8HbRov/ZAnxvv7Zy6asS+WCA==",
       "dev": true,
       "peer": true,
       "requires": {
         "invariant": "^2.2.4",
-        "metro-source-map": "0.67.0",
+        "metro-source-map": "0.70.3",
         "nullthrows": "^1.1.1",
         "source-map": "^0.5.6",
         "through2": "^2.0.1",
@@ -87686,13 +87970,17 @@
       "dependencies": {
         "source-map": {
           "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
           "dev": true,
           "peer": true
         }
       }
     },
     "metro-transform-plugins": {
-      "version": "0.67.0",
+      "version": "0.70.3",
+      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.70.3.tgz",
+      "integrity": "sha512-dQRIJoTkWZN2IVS2KzgS1hs7ZdHDX3fS3esfifPkqFAEwHiLctCf0EsPgIknp0AjMLvmGWfSLJigdRB/dc0ASw==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -87704,7 +87992,9 @@
       }
     },
     "metro-transform-worker": {
-      "version": "0.67.0",
+      "version": "0.70.3",
+      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.70.3.tgz",
+      "integrity": "sha512-MtVVsnHhhBOp9GRLCdAb2mD1dTCsIzT4+m34KMRdBDCEbDIb90YafT5prpU8qbj5uKd0o2FOQdrJ5iy5zQilHw==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -87713,13 +88003,13 @@
         "@babel/parser": "^7.14.0",
         "@babel/types": "^7.0.0",
         "babel-preset-fbjs": "^3.4.0",
-        "metro": "0.67.0",
-        "metro-babel-transformer": "0.67.0",
-        "metro-cache": "0.67.0",
-        "metro-cache-key": "0.67.0",
-        "metro-hermes-compiler": "0.67.0",
-        "metro-source-map": "0.67.0",
-        "metro-transform-plugins": "0.67.0",
+        "metro": "0.70.3",
+        "metro-babel-transformer": "0.70.3",
+        "metro-cache": "0.70.3",
+        "metro-cache-key": "0.70.3",
+        "metro-hermes-compiler": "0.70.3",
+        "metro-source-map": "0.70.3",
+        "metro-transform-plugins": "0.70.3",
         "nullthrows": "^1.1.1"
       }
     },
@@ -88197,9 +88487,6 @@
       "version": "1.0.1",
       "dev": true
     },
-    "module-not-found-error": {
-      "version": "1.0.1"
-    },
     "moment": {
       "version": "2.29.3",
       "dev": true
@@ -88387,7 +88674,9 @@
       }
     },
     "nocache": {
-      "version": "2.1.0",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/nocache/-/nocache-3.0.4.tgz",
+      "integrity": "sha512-WDD0bdg9mbq6F4mRxEYcPWwfA1vxd0mrvKOyxI7Xj/atfRHVeutzuWByG//jfm4uPzp0y4Kj051EORCBSQMycw==",
       "dev": true,
       "peer": true
     },
@@ -88551,6 +88840,8 @@
     },
     "node-stream-zip": {
       "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.15.0.tgz",
+      "integrity": "sha512-LN4fydt9TqhZhThkZIVQnF9cwjU3qmUH9h78Mx/K7d3VvfRqqwthLwJEUOEL0QPZ0XQmNN7be5Ggit5+4dq3Bw==",
       "dev": true,
       "peer": true
     },
@@ -90322,6 +90613,8 @@
     },
     "nullthrows": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
+      "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==",
       "dev": true,
       "peer": true
     },
@@ -90513,7 +90806,9 @@
       }
     },
     "ob1": {
-      "version": "0.67.0",
+      "version": "0.70.3",
+      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.70.3.tgz",
+      "integrity": "sha512-Vy9GGhuXgDRY01QA6kdhToPd8AkLdLpX9GjH5kpqluVqTu70mgOm7tpGoJDZGaNbr9nJlJgnipqHJQRPORixIQ==",
       "dev": true,
       "peer": true
     },
@@ -91407,6 +91702,8 @@
     },
     "plist": {
       "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.5.tgz",
+      "integrity": "sha512-83vX4eYdQp3vP9SxuYgEM/G/pJQqLUz/V/xzPrzruLs7fz7jxGQ1msZ/mg1nwZxUSuOp4sb+/bEIbRrbzZRxDA==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -92832,14 +93129,6 @@
         }
       }
     },
-    "proxyquire": {
-      "version": "2.1.3",
-      "requires": {
-        "fill-keys": "^1.0.2",
-        "module-not-found-error": "^1.0.1",
-        "resolve": "^1.11.1"
-      }
-    },
     "prr": {
       "version": "1.0.1",
       "dev": true
@@ -93199,7 +93488,9 @@
       }
     },
     "react-devtools-core": {
-      "version": "4.24.7",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.24.0.tgz",
+      "integrity": "sha512-Rw7FzYOOzcfyUPaAm9P3g0tFdGqGq2LLiAI+wjYcp6CsF3DeeMrRS3HZAho4s273C29G/DJhx0e8BpRE/QZNGg==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -93262,7 +93553,9 @@
       }
     },
     "react-native-codegen": {
-      "version": "0.0.17",
+      "version": "0.69.1",
+      "resolved": "https://registry.npmjs.org/react-native-codegen/-/react-native-codegen-0.69.1.tgz",
+      "integrity": "sha512-TOZEqBarczcyYN3iZE3VpKkooOevaAzBq9n7lU0h9mQUvtRhLVyolc+a5K6cWI0e4v4K69I0MqzjPcPeFKo32Q==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -93273,7 +93566,9 @@
       }
     },
     "react-native-gradle-plugin": {
-      "version": "0.0.6",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/react-native-gradle-plugin/-/react-native-gradle-plugin-0.0.7.tgz",
+      "integrity": "sha512-+4JpbIx42zGTONhBTIXSyfyHICHC29VTvhkkoUOJAh/XHPEixpuBduYgf6Y4y9wsN1ARlQhBBoptTvXvAFQf5g==",
       "dev": true,
       "peer": true
     },
@@ -97207,6 +97502,8 @@
     },
     "readline": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/readline/-/readline-1.3.0.tgz",
+      "integrity": "sha512-k2d6ACCkiNYz222Fs/iNze30rRJ1iIicW7JuX/7/cozvih6YCkFZH+J6mAFDVgv0dRBaAyr4jDqC95R2y4IADg==",
       "dev": true,
       "peer": true
     },
@@ -97215,6 +97512,8 @@
     },
     "recast": {
       "version": "0.20.5",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.20.5.tgz",
+      "integrity": "sha512-E5qICoPoNL4yU0H0NoBDntNB0Q5oMSNh9usFctYniLBluTthi3RsQVBXIJNbApOlvSwW/RGxIuokPcAc59J5fQ==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -97226,6 +97525,8 @@
       "dependencies": {
         "tslib": {
           "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
           "dev": true,
           "peer": true
         }
@@ -98515,6 +98816,8 @@
     },
     "serialize-error": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
+      "integrity": "sha512-ghgmKt5o4Tly5yEG/UJp8qTd0AN7Xalw4XBtDEKP655B699qMEtra1WlXeE6WIvdEG481JvRxULKsInq/iNysw==",
       "dev": true,
       "peer": true
     },
@@ -100234,7 +100537,6 @@
         "aws-signed-axios": "^1.1.0",
         "babel-loader": "^8.2.5",
         "lambda-logger-middleware": "^1.0.3",
-        "proxyquire": "^2.1.3",
         "serverless-api-gateway-throttling": "^2.0.1",
         "serverless-bundle": "^5.3.0",
         "serverless-iam-roles-per-function": "^3.2.0",
@@ -100314,16 +100616,6 @@
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
         "debug": "^4.3.4"
-      }
-    },
-    "simple-plist": {
-      "version": "1.3.1",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "bplist-creator": "0.1.0",
-        "bplist-parser": "0.3.1",
-        "plist": "^3.0.5"
       }
     },
     "simple-swizzle": {
@@ -100904,11 +101196,6 @@
         }
       }
     },
-    "stream-buffers": {
-      "version": "2.2.0",
-      "dev": true,
-      "peer": true
-    },
     "stream-combiner2": {
       "version": "1.1.1",
       "dev": true,
@@ -101185,6 +101472,8 @@
     },
     "sudo-prompt": {
       "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/sudo-prompt/-/sudo-prompt-9.2.1.tgz",
+      "integrity": "sha512-Mu7R0g4ig9TUuGSxJavny5Rv0egCEtpZRNMrZaYS1vxkiIxGiGUwoezU3LazIQ+KE04hTrTfNPgxU5gzi7F5Pw==",
       "dev": true,
       "peer": true
     },
@@ -102761,6 +103050,8 @@
     },
     "temp": {
       "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.4.tgz",
+      "integrity": "sha512-s0ZZzd0BzYv5tLSptZooSjK8oj6C+c19p7Vqta9+6NPOf7r+fxq0cJe6/oN4LTC79sy5NY8ucOJNgwsKCSbfqg==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -102769,6 +103060,8 @@
       "dependencies": {
         "rimraf": {
           "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -104016,6 +104309,8 @@
     },
     "uglify-es": {
       "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
+      "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -104025,6 +104320,8 @@
       "dependencies": {
         "commander": {
           "version": "2.13.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
           "dev": true,
           "peer": true
         }
@@ -104487,13 +104784,13 @@
         "use-isomorphic-layout-effect": "^1.1.1"
       }
     },
-    "use-subscription": {
-      "version": "1.5.1",
+    "use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
       "dev": true,
       "peer": true,
-      "requires": {
-        "object-assign": "^4.1.1"
-      }
+      "requires": {}
     },
     "user-service": {
       "version": "file:packages/user-service",
@@ -104631,6 +104928,8 @@
     },
     "vlq": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vlq/-/vlq-1.0.1.tgz",
+      "integrity": "sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==",
       "dev": true,
       "peer": true
     },
@@ -105586,22 +105885,6 @@
       "version": "7.5.8",
       "requires": {}
     },
-    "xcode": {
-      "version": "3.0.1",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "simple-plist": "^1.1.0",
-        "uuid": "^7.0.3"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "7.0.3",
-          "dev": true,
-          "peer": true
-        }
-      }
-    },
     "xdg-basedir": {
       "version": "4.0.0"
     },
@@ -105633,21 +105916,6 @@
     "xmlchars": {
       "version": "2.2.0",
       "dev": true
-    },
-    "xmldoc": {
-      "version": "1.1.3",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "sax": "^1.2.4"
-      },
-      "dependencies": {
-        "sax": {
-          "version": "1.2.4",
-          "dev": true,
-          "peer": true
-        }
-      }
     },
     "xtend": {
       "version": "4.0.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "slic-starter",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "slic-starter",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -62999,7 +62999,6 @@
         "aws-sdk": "^2.1153.0",
         "aws-sdk-mock": "^5.7.0",
         "b": "^2.0.1",
-        "proxyquire": "^2.1.3",
         "serverless-bundle": "^5.3.0",
         "serverless-iam-roles-per-function": "^3.2.0",
         "serverless-offline": "^8.8.0",
@@ -100402,7 +100401,7 @@
       "requires": {
         "@aws-sdk/client-cloudwatch-events": "^3.118.1",
         "@aws-sdk/client-dynamodb": "^3.118.1",
-        "@aws-sdk/client-sqs": "*",
+        "@aws-sdk/client-sqs": "^3.118.1",
         "@aws-sdk/lib-dynamodb": "^3.118.1"
       }
     },
@@ -105243,7 +105242,6 @@
         "aws-sdk-mock": "^5.7.0",
         "aws4": "^1.11.0",
         "b": "^2.0.1",
-        "proxyquire": "^2.1.3",
         "serverless-bundle": "^5.3.0",
         "serverless-iam-roles-per-function": "^3.2.0",
         "serverless-offline": "^8.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,6 @@
         "@commitlint/config-conventional": "^17.0.2",
         "@semantic-release/changelog": "^6.0.1",
         "@semantic-release/git": "^10.0.1",
-        "aws-sdk-mock": "^5.7.0",
         "awscred": "^1.5.0",
         "cz-conventional-changelog": "^3.3.0",
         "eslint": "^8.17.0",
@@ -18153,16 +18152,6 @@
       "version": "2.4.0",
       "dev": true,
       "license": "0BSD"
-    },
-    "node_modules/aws-sdk-mock": {
-      "version": "5.7.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "aws-sdk": "^2.1122.0",
-        "sinon": "^13.0.2",
-        "traverse": "^0.6.6"
-      }
     },
     "node_modules/aws-signed-axios": {
       "version": "1.1.0",
@@ -54143,50 +54132,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/sinon": {
-      "version": "13.0.2",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^1.8.3",
-        "@sinonjs/fake-timers": "^9.1.2",
-        "@sinonjs/samsam": "^6.1.1",
-        "diff": "^5.0.0",
-        "nise": "^5.1.1",
-        "supports-color": "^7.2.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/sinon"
-      }
-    },
-    "node_modules/sinon/node_modules/diff": {
-      "version": "5.1.0",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "node_modules/sinon/node_modules/has-flag": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/sinon/node_modules/supports-color": {
-      "version": "7.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/sirv": {
       "version": "1.0.19",
       "license": "MIT",
@@ -62898,7 +62843,6 @@
         "@babel/core": "^7.18.5",
         "@babel/preset-env": "^7.18.2",
         "aws-sdk": "^2.1153.0",
-        "aws-sdk-mock": "^5.7.0",
         "b": "^2.0.1",
         "serverless-bundle": "^5.3.0",
         "serverless-iam-roles-per-function": "^3.2.0",
@@ -75932,15 +75876,6 @@
           "version": "2.4.0",
           "dev": true
         }
-      }
-    },
-    "aws-sdk-mock": {
-      "version": "5.7.0",
-      "dev": true,
-      "requires": {
-        "aws-sdk": "^2.1122.0",
-        "sinon": "^13.0.2",
-        "traverse": "^0.6.6"
       }
     },
     "aws-signed-axios": {
@@ -100631,35 +100566,6 @@
         }
       }
     },
-    "sinon": {
-      "version": "13.0.2",
-      "dev": true,
-      "requires": {
-        "@sinonjs/commons": "^1.8.3",
-        "@sinonjs/fake-timers": "^9.1.2",
-        "@sinonjs/samsam": "^6.1.1",
-        "diff": "^5.0.0",
-        "nise": "^5.1.1",
-        "supports-color": "^7.2.0"
-      },
-      "dependencies": {
-        "diff": {
-          "version": "5.1.0",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
     "sirv": {
       "version": "1.0.19",
       "requires": {
@@ -105538,7 +105444,6 @@
         "@babel/core": "^7.18.5",
         "@babel/preset-env": "^7.18.2",
         "aws-sdk": "^2.1153.0",
-        "aws-sdk-mock": "^5.7.0",
         "aws4": "^1.11.0",
         "b": "^2.0.1",
         "serverless-bundle": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,6 @@
     "@commitlint/config-conventional": "^17.0.2",
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
-    "aws-sdk-mock": "^5.7.0",
     "awscred": "^1.5.0",
     "cz-conventional-changelog": "^3.3.0",
     "eslint": "^8.17.0",

--- a/package.json
+++ b/package.json
@@ -122,7 +122,6 @@
     "eslint-plugin-testcafe": "^0.2.1",
     "husky": "^8.0.1",
     "lint-staged": "^13.0.1",
-    "proxyquire": "^2.1.3",
     "semantic-release": "^19.0.3",
     "serverless": "^3.19.0",
     "tap": "^16.2.0"

--- a/packages/sharing-service/package.json
+++ b/packages/sharing-service/package.json
@@ -32,7 +32,6 @@
   "dependencies": {
     "aws-signed-axios": "^1.1.0",
     "lambda-logger-middleware": "^1.0.3",
-    "proxyquire": "^2.1.3",
     "signed-objectid": "^1.0.1",
     "slic-tools": "*"
   }

--- a/packages/sharing-service/services/sharing/confirm.js
+++ b/packages/sharing-service/services/sharing/confirm.js
@@ -2,11 +2,11 @@ const { processEvent } = require('slic-tools/event-util')
 const { middify } = require('slic-tools/middy-util')
 const share = require('./share')
 
-async function main (event, context) {
+async function main (event, { codeSecret }) {
   const { pathParameters, userId } = processEvent(event) // TODO - Remove processEvent
   const { code } = pathParameters
 
-  await share.confirm({ code, userId }, context.codeSecret)
+  await share.confirm({ code, userId }, codeSecret)
 
   return {
     statusCode: 204

--- a/packages/sharing-service/services/sharing/create.js
+++ b/packages/sharing-service/services/sharing/create.js
@@ -6,13 +6,12 @@ async function main (event, context) {
   const { body, userId } = processEvent(event)
   const { email, listId, listName } = body
 
-  const result = await share.create(
+  await share.create(
     { email, listId, listName, userId },
     context.codeSecret, context.userServiceUrl, context.frontendUrl
   )
   return {
-    statusCode: 201,
-    body: result
+    statusCode: 201
   }
 }
 

--- a/packages/welcome-service/package.json
+++ b/packages/welcome-service/package.json
@@ -22,7 +22,6 @@
     "aws-sdk": "^2.1153.0",
     "aws-sdk-mock": "^5.7.0",
     "b": "^2.0.1",
-    "proxyquire": "^2.1.3",
     "serverless-bundle": "^5.3.0",
     "serverless-iam-roles-per-function": "^3.2.0",
     "serverless-offline": "^8.8.0",

--- a/packages/welcome-service/package.json
+++ b/packages/welcome-service/package.json
@@ -20,7 +20,6 @@
     "@babel/core": "^7.18.5",
     "@babel/preset-env": "^7.18.2",
     "aws-sdk": "^2.1153.0",
-    "aws-sdk-mock": "^5.7.0",
     "b": "^2.0.1",
     "serverless-bundle": "^5.3.0",
     "serverless-iam-roles-per-function": "^3.2.0",

--- a/packages/welcome-service/services/welcome/new-checklist-handler.js
+++ b/packages/welcome-service/services/welcome/new-checklist-handler.js
@@ -4,8 +4,12 @@ const { sendEmail } = require('slic-tools/email-util')
 const log = require('slic-tools/log')
 
 async function handleNewChecklist (event, context) {
-  const checklist = event.detail
-  const { userId, name } = checklist
+  const {
+    detail: {
+      userId,
+      name
+    }
+  } = event
 
   log.info({ context }, 'context')
   const { email } = await getUser(userId, context.userServiceUrl)


### PR DESCRIPTION
* `proxyquire` can be replaced with `t.mock` since it provides the same functionality and is already included out of the box with `tap` for mocking
* This change removes the use of `proxyquire` in favour of `t.mock` instead